### PR TITLE
Adjusted sell_max_tech to reduce repeated undercuts

### DIFF
--- a/techer_strat.php
+++ b/techer_strat.php
@@ -194,11 +194,16 @@ function sell_max_tech(&$c)
         if ($q == 0) {
             $price[$key] = 0;
         } elseif (PublicMarket::price($key) != null) {
-            Debug::msg("sell_max_tech:A:$key");
-            $max = $c->goodsStuck($key) ? 0.98 : $rmax; //undercut if we have goods stuck
-            Debug::msg("sell_max_tech:B:$key");
-            $price[$key] = min(9999, floor(PublicMarket::price($key) * Math::purebell($rmin, $max, $rstddev, $rstep)));
-            Debug::msg("sell_max_tech:C:$key");
+            // additional check to make sure we aren't repeatedly undercutting with minimal goods
+            if ($q < 100 && PublicMarket::available($key) < 1000) {
+                $price[$key] = PublicMarket::price($key);
+            } else {
+                Debug::msg("sell_max_tech:A:$key");
+                $max = $c->goodsStuck($key) ? 0.98 : $rmax; //undercut if we have goods stuck
+                Debug::msg("sell_max_tech:B:$key");
+                $price[$key] = min(9999, floor(PublicMarket::price($key) * Math::purebell($rmin, $max, $rstddev, $rstep)));
+                Debug::msg("sell_max_tech:C:$key");
+            }
         } else {
             $price[$key] = floor(Math::purebell($nogoods_low, $nogoods_high, $nogoods_stddev, $nogoods_step));
         }


### PR DESCRIPTION
No worries if you don't want to include this, it was just a quick fix that came up during the discussion yesterday and an easy way to test the pull request :)

I added a small fix to reduce the constant small batch tech price undercuts that Celphi and Gerdler had issues with.

The techer sell_max_tech function will now check if:
1. It is attempting to sell less than 100 of a given tech
2. There are less than 1000 units of that tech on the market at the current price.

If these two conditions are met, then sell tech at the current price rather than at a purebell lower amount. This should at least slow the price undercutting when the bots are selling minimal quantities. 