### PR TITLE
Changed  event to NEW_EVENTS as this is what it is actually expecting

### DIFF
--- a/communication.php
+++ b/communication.php
@@ -197,7 +197,7 @@ function expected_result($input)
         'ally/cancel' => 'ALLYCANCEL',
         'gdi/join' => 'GDIJOIN',
         'gdi/leave' => 'GDILEAVE',
-        'events' => 'EVENTSNEW',
+        'events' => 'NEW_EVENTS',
     ];
 
     return $expected[$lastFunction] ?? null;


### PR DESCRIPTION
It looks like the $response var is expecting "NEW_EVENTS" instead of "EVENTSNEW" and that was failing the check here: 
elseif (expected_result($function) && $message != expected_result($function))

Changed and everything is running again.