### PR TITLE
Better selling of goods, add stockpiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.php
 settings.json
+zz_lock.txt
 /logging

--- a/Country.class.php
+++ b/Country.class.php
@@ -274,6 +274,7 @@ class Country
             default:
                 $govt = 1.0;
         }
+        // FUTURE: this is wrong - reps have a higher calculated NW/acre as a result
 
         return floor($this->networth / ($this->land * $govt));
     }//end nlg()

--- a/Country.class.php
+++ b/Country.class.php
@@ -40,7 +40,7 @@ class Country
     }//end __construct()
 
 
-    public function updateMain()
+    public function updateMain() // WARNING: this does not update bushel consumption!
     {
         $main           = get_main();                 //Grab a fresh copy of the main stats
         $this->money    = $main->money;       //might as well use the newest numbers?

--- a/Country.class.php
+++ b/Country.class.php
@@ -577,10 +577,11 @@ class Country
      * Check to see if we should build a single CS
      *
      * @param  int $target_bpt The target bpt
-     *
+     * @param  int $low_bpt The bpt considered to be "low" in the code
+     * 
      * @return bool            Build or not
      */
-    public function shouldBuildSingleCS($target_bpt = 80)
+    public function shouldBuildSingleCS($target_bpt = 80, $low_bpt = 30)
     {
         if (!$this->empty) {
             //no empty land
@@ -597,7 +598,7 @@ class Country
             return false;
         }
 
-        if ($this->bpt < 30 && $this->built() <= 50) {
+        if ($this->bpt < $low_bpt && $this->built() <= 50) {
             //you have low BPT and low Builtings
             return true;
         } elseif ($this->bpt < $target_bpt && $this->b_cs % 4 != 0) {

--- a/Country.class.php
+++ b/Country.class.php
@@ -184,7 +184,7 @@ class Country
         }
     }//end setIndy()
 
-
+/*
     public function setIndyFromMarket($checkDPA = false)
     {
         // produce 100% turrets if checked in the first 150 turns because there's very little demand for anything else
@@ -197,22 +197,6 @@ class Country
             // 200 was too low - maybe because of OOF and OOM events?
             $spy = max(1, min(5, round(400 / ($this->b_indy + 1))));
 
-            // commented out by Slagpit 20210323 - not clear why indies want so many spies
-            /*
-            if ($this->m_spy < 10000) {
-                $spy = 10;
-            } elseif ($this->m_spy / $this->land < 25) {
-                $spy = 5;
-            } elseif ($this->m_spy / $this->land < 30) {
-                $spy = 4;
-            } elseif ($this->m_spy / $this->land < 35) {
-                $spy = 3;
-            } elseif ($this->m_spy / $this->land < 40) {
-                $spy = 2;
-            } else {
-                $spy = 1;
-            }
-            */
             $therest = 100 - $spy;
 
             $new = ['pro_spy' => $spy];
@@ -251,7 +235,7 @@ class Country
 
         $this->setIndy($new);
     }//end setIndyFromMarket()
-
+*/
 
     /**
      * How much money it will cost to run turns

--- a/Country.class.php
+++ b/Country.class.php
@@ -184,58 +184,6 @@ class Country
         }
     }//end setIndy()
 
-/*
-    public function setIndyFromMarket($checkDPA = false)
-    {
-        // produce 100% turrets if checked in the first 150 turns because there's very little demand for anything else
-        // FUTURE: 150 is a made up number that could be changed to something better
-        if ($this->turns_played < 150) { 
-            $new['pro_tu'] = 100;
-        }
-        else { // not the first 150 turns
-            // for now, 400 indy's worth of production with 1% min and 5% max
-            // 200 was too low - maybe because of OOF and OOM events?
-            $spy = max(1, min(5, round(400 / ($this->b_indy + 1))));
-
-            $therest = 100 - $spy;
-
-            $new = ['pro_spy' => $spy];
-            global $market;
-
-            $p_tr = PublicMarket::price('m_tr');
-            $p_j  = PublicMarket::price('m_j');
-            $p_tu = PublicMarket::price('m_tu');
-            $p_ta = PublicMarket::price('m_ta');
-
-            $score = [
-                'pro_tr'  => 1.86 * ($p_tr == 0 ? 144 : $p_tr),
-                'pro_j'   => 1.86 * ($p_j == 0 ? 192 : $p_j),
-                'pro_tu'  => 1.86 * ($p_tu == 0 ? 210 : $p_tu),
-                'pro_ta'  => 0.4 * ($p_ta == 0 ? 588 : $p_ta),
-            ];
-
-            $protext = null;
-            foreach ($score as $k => $s) {
-                $protext .= $s.' '.$k.' ';
-            }
-            log_country_message($this->cnum, "--- Indy Scoring: ".$protext);
-
-            if ($checkDPA) {
-                $target = $this->dpat ?? $this->defPerAcreTarget();
-                if ($this->defPerAcre() < $target) {
-                    //below def target, don't make jets
-                    unset($score['pro_j']);
-                }
-            }
-
-            arsort($score);
-            $which       = key($score);
-            $new[$which] = $therest; //set to do the most expensive of whatever other good
-        }
-
-        $this->setIndy($new);
-    }//end setIndyFromMarket()
-*/
 
     /**
      * How much money it will cost to run turns

--- a/Destocking.php
+++ b/Destocking.php
@@ -199,7 +199,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 
 	log_country_message($cnum, "Completed all PM purchasing. Money is $c->money and budget is $max_spend");
 	log_country_message($cnum, "Estimated future PM gen capacity is $total_cost_to_buyout_future_private_market dollars");
-	
+
 	$did_resell_military = false;
 	// check if this is our last shot at destocking
 	if($is_final_destocking_attempt) {		
@@ -289,6 +289,10 @@ function dump_tech(&$c, $strategy, $market_autobuy_tech_price, $server_max_possi
 		$turns_needed += 3;
 	}
 
+	// we may have just bought a lot of military which means that expenses and food consumption will have gone up, but $c will be out of date
+	if ($strategy == 'T') // FUTURE: change when we add support for non-techers
+		$c = get_advisor();
+
 	// I don't care if a country could sell a tech but not recall tech - ok to not do anything and try again later
 	$food_needed = max(0, get_food_needs_for_turns($turns_needed, $c->foodpro, $c->foodcon, true) - $c->food);
 
@@ -367,6 +371,9 @@ function consider_and_do_military_reselling(&$c, $value_of_public_market_goods, 
 		$reason_for_not_reselling_military = "No turns";	
 
 	if($reason_for_not_reselling_military == null) {
+		// we may have just bought a lot of military which means that expenses and food consumption will have gone up, but $c will be out of date
+		$c = get_advisor();
+
 		// buy food to play a turn if needed up to $80 in price
 		// it's food for one turn so I don't care if players know about this behavior
 		$food_needed = max(0, get_food_needs_for_turns(1, $c->foodpro, $c->foodcon, true) - $c->food);

--- a/Destocking.php
+++ b/Destocking.php
@@ -55,7 +55,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 
 	$bushel_market_history_info = get_market_history('food', $cpref->market_search_look_back_hours);
 	log_country_message($cnum, "The average public bushel sell price is $bushel_market_history_info->avg_price over the past $cpref->market_search_look_back_hours hours");
-	$estimated_public_market_bushel_sell_price = max(get_max_demo_bushel_recycle_price($rules) - 2, round($bushel_market_history_info->avg_price, 0) - mt_rand(0, 3));
+	$estimated_public_market_bushel_sell_price = max(get_max_demo_bushel_recycle_price($rules) - 2, floor($bushel_market_history_info->avg_price) - 1); // undercut because we're dumping
 	log_country_message($cnum, "Estimated public bushel sell price is $estimated_public_market_bushel_sell_price");
 
 	// get what's on the market so we can recall goods or tech as needed depending on time left in reset

--- a/Destocking.php
+++ b/Destocking.php
@@ -55,7 +55,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 
 	$bushel_market_history_info = get_market_history('food', $cpref->market_search_look_back_hours);
 	log_country_message($cnum, "The average public bushel sell price is $bushel_market_history_info->avg_price over the past $cpref->market_search_look_back_hours hours");
-	$estimated_public_market_bushel_sell_price = max(get_max_demo_bushel_recycle_price($rules) - 2, $bushel_market_history_info->avg_price - mt_rand(0, 3));
+	$estimated_public_market_bushel_sell_price = max(get_max_demo_bushel_recycle_price($rules) - 2, round($bushel_market_history_info->avg_price, 0) - mt_rand(0, 3));
 	log_country_message($cnum, "Estimated public bushel sell price is $estimated_public_market_bushel_sell_price");
 
 	// get what's on the market so we can recall goods or tech as needed depending on time left in reset

--- a/Destocking.php
+++ b/Destocking.php
@@ -318,7 +318,7 @@ function dump_tech(&$c, $strategy, $market_autobuy_tech_price, $server_max_possi
 		}
 
 		if ($mil_tech_to_keep) {
-			log_country_message($c->cnum, "With $c->land acres and $c->t_mil mil tech points, a demo should keep $mil_tech_to_keep mil tech");
+			log_country_message($c->cnum, "With $c->land acres and $c->t_mil mil tech points, a ".($c->govt == 'D' ? 'demo' : 'non-demo')." should keep $mil_tech_to_keep mil tech");
 		}
 
 		// if there's time in the set or if auto buy prices are bad, do a normal tech sale

--- a/Destocking.php
+++ b/Destocking.php
@@ -51,11 +51,11 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 	$is_final_destocking_attempt = (($debug_force_final_attempt or $calc_final_attempt) ? true : false);
 
 	
-	$bushel_market_history_info = get_market_history('food', $cpref->market_search_look_back_hours);
+	$bushel_market_history_info = get_market_history('food', 2); // want to respond to the latest food prices so the stockpile sells
 	log_country_message($cnum, "The average public bushel sell price is $bushel_market_history_info->avg_price over the past $cpref->market_search_look_back_hours hours");
 	// reasonable to assume that a demo country will resell bushels for $1 less than max PM sell price on all servers
 	// undercut by $1 because we're dumping
-	$estimated_public_market_bushel_sell_price = max(get_max_demo_bushel_recycle_price($rules), floor($bushel_market_history_info->avg_price)) - 1;
+	$estimated_public_market_bushel_sell_price = max(get_max_demo_bushel_recycle_price($rules) - 1, floor($bushel_market_history_info->avg_price) - 3);
 	log_country_message($cnum, "Estimated public bushel sell price is $estimated_public_market_bushel_sell_price");
 
 	// get what's on the market so we can recall goods or tech as needed depending on time left in reset

--- a/Destocking.php
+++ b/Destocking.php
@@ -240,7 +240,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 		log_country_message($cnum, "Considering military reselling...", 'green');
 		$did_resell_military = consider_and_do_military_reselling($c, $value_of_public_market_goods, $total_cost_to_buyout_future_private_market, $rules->max_possible_market_sell, $reset_seconds_remaining, $max_market_package_time_in_seconds, $is_final_destocking_attempt);
 
-		log_country_message($cnum, "Considering tech sale...");
+		log_country_message($cnum, "Considering tech sale...", 'green');
 		dump_tech($c, $strategy, $market_autobuy_tech_price, $rules->max_possible_market_sell, $reset_seconds_remaining, $max_market_package_time_in_seconds, $tech_recall_needed, $is_final_destocking_attempt, $cpref);
 	}
 	

--- a/Destocking.php
+++ b/Destocking.php
@@ -89,7 +89,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 	}
 
 	// note that we stay logged out for at least 6 turns
-	$turns_to_keep = 6; // 1 to sell bushels and 1 to sell military, along with 3 to possibly recall bushels and sell again in the future
+	$turns_to_keep = 6; // 1 to sell bushels and 1 to sell military, along with 3 to possibly recall bushels and sell again in later logins
 	$tech_recall_needed = false;
 	if($strategy == 'T') // one turn to sell tech
 		$turns_to_keep += 1;
@@ -104,7 +104,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 	// stash bushels away on public market if needed
 	$expect_to_play_turns_for_income = temporary_cash_or_tech_at_end_of_set ($c, $strategy, $turns_to_keep, $money_to_reserve_temp, true);
 	if($expect_to_play_turns_for_income and $c->turns >= 20 + $turns_to_keep) {
-		if(stash_excess_bushels_on_public_if_needed($c, $rules, $estimated_public_market_bushel_sell_price)) { // sold bushels
+		if(stash_excess_bushels_on_public_if_needed($c, $rules, $estimated_public_market_bushel_sell_price)) { // sold bushels FUTURE: WATCH RETURN VALUE
 			if(!$bushel_recall_needed and !is_there_time_to_sell_on_public($reset_seconds_remaining, $max_market_package_time_in_seconds, $is_final_destocking_attempt, 1800)) {
 				$turns_to_keep += 3; // we are going to recall bushels, so save 3 more turns for that
 				$bushel_recall_needed = true;
@@ -120,7 +120,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 	$was_playing_turns_profitable = temporary_cash_or_tech_at_end_of_set ($c, $strategy, $turns_to_keep, $money_to_reserve);
 	log_country_message($cnum, "Finished cashing or teching");
 
-	// FUTURE: switch governments if that would help
+	// FUTURE: switch governments if that would help???
 	
 	// recall bushels if needed - TODO: function
 	if($bushel_recall_needed) {

--- a/Destocking.php
+++ b/Destocking.php
@@ -332,8 +332,6 @@ function dump_tech(&$c, $strategy, $market_autobuy_tech_price, $server_max_possi
 		}
 
 		$turn_result = sell_max_tech($c, $cpref, $market_autobuy_tech_price, $server_max_possible_market_sell, $mil_tech_to_keep, $dump_at_min_sell_price, $allow_average_prices, $tech_price_history);
-
-		sell_max_tech($c, $cpref, $tech_price_min_sell_price, $server_max_possible_market_sell, 0, false, true, $tech_price_history);
 		update_c($c, $turn_result);
 	}
 

--- a/Destocking.php
+++ b/Destocking.php
@@ -323,7 +323,17 @@ function dump_tech(&$c, $strategy, $market_autobuy_tech_price, $server_max_possi
 
 		// if there's time in the set or if auto buy prices are bad, do a normal tech sale
 		$dump_at_min_sell_price = ($can_sell_at_market_prices or $market_autobuy_tech_price <= $cpref->base_inherent_value_for_tech) ? false : true;
-		$turn_result = sell_max_tech($c, $market_autobuy_tech_price, $server_max_possible_market_sell, $mil_tech_to_keep, $dump_at_min_sell_price);
+		$allow_average_prices = false;
+		$tech_price_history = [];
+		// if not dumping tech at min prices, we have the option to sell by average price
+		if(!$dump_at_min_sell_price) {
+			$allow_average_prices = true;
+			$tech_price_history = get_market_history_all_tech($c->cnum, $cpref);
+		}
+
+		$turn_result = sell_max_tech($c, $cpref, $market_autobuy_tech_price, $server_max_possible_market_sell, $mil_tech_to_keep, $dump_at_min_sell_price, $allow_average_prices, $tech_price_history);
+
+		sell_max_tech($c, $cpref, $tech_price_min_sell_price, $server_max_possible_market_sell, 0, false, true, $tech_price_history);
 		update_c($c, $turn_result);
 	}
 

--- a/Destocking.php
+++ b/Destocking.php
@@ -116,6 +116,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 		}
 	}
 
+	// TODO: techers can end up with empty acres here - don't explore in final 30% of set?
 	$money_to_reserve = $turns_to_keep * max(-1 * $c->income, 10000000); // mil expenses can rise rapidly during destocking, so use 10 M per turn as a guess
 	// FUTURE: indies (and maybe other strats) should reserve money to play the rest of the turns they'll get in the set. see $turns_to_keep_for_bushel_calculation
 	log_country_message($cnum, "Money is $c->money and calculated money to reserve is $money_to_reserve");

--- a/Destocking.php
+++ b/Destocking.php
@@ -211,7 +211,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 
 		if($c->money > 10000000) {
 			log_country_message($cnum, "Buying anything available off public market...");
-			buyout_up_to_market_dpnw($c, $cpref, 5000, $c->money, false, false); // buy anything ($10000 tech is 5000 dpnw)
+			buyout_up_to_market_dpnw($c, $cpref, 5500, $c->money, false, false); // buy anything ($10000 tech is 5500 dpnw with 10% tax)
 			log_country_message($cnum, "Done with public market purchases. Money is $c->money");
 		}
 		else

--- a/Destocking.php
+++ b/Destocking.php
@@ -116,7 +116,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 	// FUTURE: indies (and maybe other strats) should reserve money to play the rest of the turns they'll get in the set. see $turns_to_keep_for_bushel_calculation
 	log_country_message($cnum, "Money is $c->money and calculated money to reserve is $money_to_reserve");
 	log_country_message($cnum, "Turns left: $c->turns and turns to keep is $turns_to_keep");
-	log_country_message($cnum, "Starting cashing or teching...");	
+	log_country_message($cnum, "Starting cashing or teching...", 'green');	
 	$was_playing_turns_profitable = temporary_cash_or_tech_at_end_of_set ($c, $strategy, $turns_to_keep, $money_to_reserve);
 	log_country_message($cnum, "Finished cashing or teching");
 
@@ -153,7 +153,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 	$pm_info = PrivateMarket::getInfo();
 	$private_market_bushel_price = $pm_info->sell_price->m_bu;	
 
-	log_country_message($cnum, "Attempting to dump bushel stock...");
+	log_country_message($cnum, "Attempting to dump bushel stock...", 'green');
 	// keep bushels to keep running future turns if it's profitable to do so
 	$turns_to_keep_for_bushel_calculation = ($was_playing_turns_profitable ? min($rules->maxturns, $turns_left_in_set) : $turns_to_keep);
 	log_country_message($cnum, "Turns of bushels to keep is: $turns_to_keep_for_bushel_calculation");
@@ -165,7 +165,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 
 	// resell bushels if profitable
 	$should_attempt_bushel_reselling = can_resell_bushels_from_public_market ($private_market_bushel_price, $c->tax(), $current_public_market_bushel_price, $max_profitable_public_market_bushel_price);
-	log_country_message($cnum, "Decision on attempting public market bushel reselling: ".log_translate_boolean_to_YN($should_attempt_bushel_reselling));
+	log_country_message($cnum, "Decision on attempting public market bushel reselling: ".log_translate_boolean_to_YN($should_attempt_bushel_reselling), 'green');
 	if ($should_attempt_bushel_reselling) {
 		do_public_market_bushel_resell_loop ($c, $max_profitable_public_market_bushel_price);
 		log_country_message($cnum, "Done with bushel reselling");
@@ -184,7 +184,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 		log_country_message($cnum, "For $military_unit market buying loop, total money is $c->money and budget is $max_spend");
 
 		if ($max_spend > 0) {
-			log_country_message($cnum, "Attempting to spend money on private and public markets on units better or equal to PM $military_unit...");
+			log_country_message($cnum, "Attempting to spend money on private and public markets on units better or equal to PM $military_unit...", 'green');
 			buyout_up_to_private_market_unit_dpnw ($c, $cpref, $pm_info->buy_price->$military_unit, $military_unit, $max_spend);
 		}
 
@@ -205,7 +205,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 	if($is_final_destocking_attempt) {		
 		// note: a human would recall all military goods here, but I don't care if bots lose NW at the end if it allows a human to buy something
 		
-		log_country_message($cnum, "This is the FINAL destock attempt for this country". log_translate_forced_debug($debug_force_final_attempt));
+		log_country_message($cnum, "This is the FINAL destock attempt for this country". log_translate_forced_debug($debug_force_final_attempt), 'green');
 		log_country_message($cnum, "Selling all food and oil (if possible) on private market for any price...");
 		final_dump_all_resources($c, $is_oil_on_pm);
 
@@ -219,7 +219,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 
 	}
 	else { // not final attempt
-		log_country_message($cnum, "This is NOT the final destock attempt for this country");
+		log_country_message($cnum, "This is NOT the final destock attempt for this country", 'green');
 
 		// FUTURE: use SOs and recent market data to avoid getting ripped off
 		$max_dpnw = calculate_maximum_dpnw_for_public_market_purchase ($reset_seconds_remaining, $server_seconds_per_turn, $pm_info->buy_price->m_tu, $c->tax());
@@ -237,7 +237,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 		// consider putting up military for sale if we have money to play a turn and we expect to have at least 100 M in unspent PM capacity
 		// note: no need to reserve money in previous has_money_for_turns call - we reserved money earlier so we could spend turns like this
 		$value_of_public_market_goods = floor(get_total_value_of_on_market_goods($c));
-		log_country_message($cnum, "Considering military reselling...");
+		log_country_message($cnum, "Considering military reselling...", 'green');
 		$did_resell_military = consider_and_do_military_reselling($c, $value_of_public_market_goods, $total_cost_to_buyout_future_private_market, $rules->max_possible_market_sell, $reset_seconds_remaining, $max_market_package_time_in_seconds, $is_final_destocking_attempt);
 
 		log_country_message($cnum, "Considering tech sale...");

--- a/Destocking.php
+++ b/Destocking.php
@@ -87,9 +87,9 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 
 	// figure out how many turns we should save for things like recalling goods and making sales
 	// note that we stay logged out for at least 6 turns
-	$turns_to_keep = 6; // 1 to sell bushels and 1 to sell military, along with 3 to possibly recall bushels and sell again in later logins
+	$turns_to_keep = $is_final_destocking_attempt ? 0 : 6; // 1 to sell bushels and 1 to sell military, along with 3 to possibly recall bushels and sell again in later logins
 	$tech_recall_needed = false;
-	if($strategy == 'T') // one turn to sell tech
+	if($strategy == 'T' && !$is_final_destocking_attempt) // one turn to sell tech
 		$turns_to_keep += 1;
 	if($strategy == 'T' && !$is_final_destocking_attempt && $market_autobuy_tech_price > $cpref->base_inherent_value_for_tech && $expensive_tech_on_market && !is_there_time_for_selling_tech_at_market_prices($reset_seconds_remaining, $max_market_package_time_in_seconds, $market_autobuy_tech_price, $is_final_destocking_attempt, $cpref)) {
 		$turns_to_keep += 3; // probably need to recall tech, so save 3 more turns for that

--- a/Logging.php
+++ b/Logging.php
@@ -739,10 +739,7 @@ function userErrorHandler($errno, $errmsg, $filename, $linenum) {
     
     //Terminate script if fatal error
     if($errno != 2 && $errno != 8 && $errno != 512 && $errno != 1024 && $errno != 2048){
-        if($errorlogging >= 2 || $user && $debug)
-            die("A fatal error has occured. Script execution has been aborted:<br />\n$str");
-        else
-            die("A fatal error has occured. Script execution has been aborted");
+        die("A fatal error has occured. Script execution has been aborted");
     }
 }
 

--- a/Logging.php
+++ b/Logging.php
@@ -59,7 +59,9 @@ function log_get_name_of_error_type($error_type) {
     if($error_type == 122)
         return 'TECHER COMPUTING ZERO SELL';
     if($error_type == 123)
-        return 'INVALID CPREF VALUES';       
+        return 'INVALID CPREF VALUES';
+    if($error_type == 124)
+        return 'INVALID NEXTPLAY VALUE';             
 
         
     if($error_type == 999) // use when functions are given stupid input and it isn't worth defining a new error

--- a/Logging.php
+++ b/Logging.php
@@ -123,11 +123,13 @@ function log_get_name_of_error_type($error_type) {
 
 
 function update_intended_action_array(&$turn_action_counts, $action_and_turns_used) {
-    foreach($action_and_turns_used as $action => $turns_used) {
-        if(isset($turn_action_counts[$action]))
-            $turn_action_counts[$action] += $turns_used;
-        else
-            $turn_action_counts[$action] = $turns_used;
+    if(!empty($action_and_turns_used)) {
+        foreach($action_and_turns_used as $action => $turns_used) {
+            if(isset($turn_action_counts[$action]))
+                $turn_action_counts[$action] += $turns_used;
+            else
+                $turn_action_counts[$action] = $turns_used;
+        }
     }
     return;
 }

--- a/Logging.php
+++ b/Logging.php
@@ -146,6 +146,13 @@ function log_country_data($cnum_input, $data, $intro_message) {
     log_country_message($cnum_input, $message);
 }
 
+
+function log_country_market_history_for_single_unit($cnum_input, $unit_name, $unit_market_history) {    
+    $message = "Market history for $unit_name: ".($unit_market_history['no_results'] ? "no data" : json_encode($unit_market_history));
+    log_country_message($cnum_input, $message);
+}
+
+
 // examples of things to log: what decisions were made (and why), how turns are spent
 function log_country_message($cnum_input, $message, $color = null) {
     global $log_country_to_screen, $log_to_local, $local_file_path;

--- a/Logging.php
+++ b/Logging.php
@@ -2,8 +2,6 @@
 
 namespace EENPC;
 
-// FUTURE: windows support for local logging?
-
 // new error types must be added to this function
 function log_get_name_of_error_type($error_type) {
     // 40 character limit on name
@@ -122,7 +120,7 @@ function log_get_name_of_error_type($error_type) {
 
 
 
-function update_intended_action_array(&$turn_action_counts, $action_and_turns_used) {
+function update_turn_action_array(&$turn_action_counts, $action_and_turns_used) {
     if(!empty($action_and_turns_used)) {
         foreach($action_and_turns_used as $action => $turns_used) {
             if(isset($turn_action_counts[$action]))
@@ -148,7 +146,14 @@ function log_turn_action_counts($c, $server, $cpref, $turn_action_counts) {
             log_error_message(1005, $c->cnum, "Cashed ".$turn_action_counts['cash']." turns too early in the set");
     }
 
-    // FUTURE: more errors?
+    /* FUTURE: log these
+	logged out with money < -income
+	logged out with no food
+	hit 25% of max stored turns
+	hit 100% of max stored turns
+	farmer didn't sell
+	indy didn't sell
+    */
 
     return;                      
 }
@@ -266,7 +271,7 @@ function log_to_targets($log_to_screen, $log_to_local, $local_file_path_and_name
             $file_message = $timestamp_for_file.($line_break_count > 0 ? "\n" : "").preg_replace('/\e[[][A-Za-z0-9];?[0-9]*m?/', '', $message)."\n";
         }
         if($local_file_path_and_name) {
-            file_put_contents ($local_file_path_and_name, $file_message, FILE_APPEND); // FUTURE: what if this doesn't work? like if we have a read only file?
+            file_put_contents ($local_file_path_and_name, $file_message, FILE_APPEND);
         }  
     }
 

--- a/Logging.php
+++ b/Logging.php
@@ -181,12 +181,12 @@ function log_snapshot_message($c, $rules, $snapshot_type, $strat, $is_destocking
     global $log_country_to_screen, $log_to_local, $local_file_path;
 
     if($snapshot_type <> 'BEGIN' and $snapshot_type <> 'DELTA' and $snapshot_type <> 'END') {
-        die('Called log_snapshot_message() with invalid parameter value '.$snapshot_type.' for $snapshot_type');
+        log_error_message(999, $c->cnum, 'log_snapshot_message(): called with invalid parameter value '.$snapshot_type.' for $snapshot_type');
         return false;
     }
 
     if($snapshot_type == 'DELTA' and empty($prev_c_values)) {
-        die('Called log_snapshot_message() in DELTA mode with empty previous country values array');
+        log_error_message(999, $c->cnum, 'log_snapshot_message(): called in DELTA mode with empty previous country values array');
         return false;
     }   
 
@@ -772,7 +772,7 @@ function get_log_error_type_from_PHP_errno($errno) {
 }
 
 
-// TODO: does this log die() commands?
+// note: this won't catch die()
 function handleShutdown(){
     $error = error_get_last();
     if($error !== NULL){

--- a/Logging.php
+++ b/Logging.php
@@ -169,7 +169,7 @@ function log_static_cpref_on_turn_0 ($c, $cpref) {
 
     $log_message = "Printing static country preferences:";
     foreach($static_prefs as $pref_name)
-        $log_message .= "\n    $pref_name: $cpref->$pref_name";
+        $log_message .= "\n    $pref_name: ".$cpref->$pref_name;
 
     return log_country_message($c->cnum, $log_message);
 }

--- a/Logging.php
+++ b/Logging.php
@@ -2,6 +2,9 @@
 
 namespace EENPC;
 
+// TODO: have a separate error file for PHP warnings and errors
+
+
 // new error types must be added to this function
 function log_get_name_of_error_type($error_type) {
     // 40 character limit on name

--- a/Math.class.php
+++ b/Math.class.php
@@ -47,6 +47,12 @@ class Math
         return max($mean, self::purebell($purebell_min, $max, $std_deviation, $step));
     }
 
+    public static function half_bell_truncate_right_side($mean, $min, $std_deviation, $step = 1) {
+        $purebell_max = $mean + ($mean - $min);
+        return min($mean, self::purebell($min, $purebell_max, $std_deviation, $step));
+    }
+
+
     /**
      * Calculate the standard deviation
      *

--- a/PublicMarket.class.php
+++ b/PublicMarket.class.php
@@ -255,7 +255,7 @@ class PublicMarket
 
     // return amount spent
     // $tech_limit is an amount of tech that the country should not exceed
-    public static function buy_tech(&$c, $tech = 't_bus', $max_spend = null, $maxprice = 9999, $tech_limit = 999999999)
+    public static function buy_tech(&$c, $tech = 't_bus', $max_spend = null, $maxprice = 9999, $tech_limit = 999999999) // , &$last_price TODO
     {
         // $max_spend is now static, spent money is tracked via $total_spent
         $update = false;

--- a/PublicMarket.class.php
+++ b/PublicMarket.class.php
@@ -255,7 +255,7 @@ class PublicMarket
 
     // return amount spent
     // $tech_limit is an amount of tech that the country should not exceed
-    public static function buy_tech(&$c, $tech = 't_bus', $max_spend = null, $maxprice = 9999, $tech_limit = 999999999) // , &$last_price TODO
+    public static function buy_tech(&$c, $tech = 't_bus', $max_spend = null, $maxprice = 9999, $tech_limit = 999999999) // , &$last_price FUTURE
     {
         // $max_spend is now static, spent money is tracked via $total_spent
         $update = false;

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -623,7 +623,7 @@ function estimate_future_private_market_capacity_for_military_unit($military_uni
 
 function attempt_to_recycle_bushels_but_avoid_buyout(&$c, $cpref, &$food_price_history) {
     if($cpref->should_demo_attempt_bushel_recycle && $c->govt == 'D' && $c->turns_played >= 300) {
-        if($food_price_history === []) // cache this for future calls
+        if(empty($food_price_history)) // cache this for future calls
             $food_price_history = get_market_history_food($c->cnum, $cpref);
 
         $avg_price = floor($food_price_history['avg_price']);
@@ -638,7 +638,7 @@ function attempt_to_recycle_bushels_but_avoid_buyout(&$c, $cpref, &$food_price_h
         $will_recycle_be_profitable = can_resell_bushels_from_public_market ($private_market_bushel_price, 1, $avg_price, $dummy);
 
         if($will_recycle_be_profitable) {
-            log_country_message($c->cnum, "Attempting to recycle bushels because it is expected to be profitable and $food_public_price is below average price of $avg_price");
+            log_country_message($c->cnum, "Attempting to recycle bushels because it is expected to be profitable and $food_public_price is below average price of $avg_price", 'green');
             do_public_market_bushel_resell_loop ($c, $avg_price); // don't allow buying above average to hopefully avoid food buyouts
             return true;
         }

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -563,8 +563,6 @@ function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_prio
                         * ($a['t'] <=> $b['t']) // we go through this trouble to get a somewhat random order for bus/res
                         : 0                         
                      );
-                     // NOTE: the ordering does not work out as expected with quantity ties, but seems to be random enough
-                     // personally I believe there's a bug in usort()
                 });
             log_country_data($c->cnum, $optimal_tech_buying_array[$turn_bucket], "Results for optimal tech array at $turn_bucket% turn goal:");
         }

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -535,6 +535,7 @@ function get_optimal_tech_buying_array($c, $eligible_techs, $buying_priorities, 
     ];
     */
 
+    ksort($optimal_tech_buying_array, SORT_NUMERIC ); // print in expected order
     if($was_server_queried_at_least_once) {
         if(empty($optimal_tech_buying_array))
             log_country_message($c->cnum, "Optimal tech buying array is empty because prices are too expensive");

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -472,10 +472,7 @@ function get_extra_income_affected_by_tech ($c, $tech_type, $rules) {
 
 
 function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_priorities, $max_tech_price, $base_tech_value, $force_all_turn_buckets = false) {
-    // TODO: fix tech buying price buckets
-    // find max price in gc code, start at max, substract rand(0, 500), then subtract 500 each time
-    // also tune the buckets a bit
-    // for bus and res, use the same starting point (min of both techs)
+    // TODO: test changed ai_base calcs (will need to commit)
 
     $turn_buckets = [];
     if($force_all_turn_buckets) {
@@ -502,7 +499,11 @@ function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_prio
 
     $was_server_queried_at_least_once = false;
     foreach($tech_type_to_ipa as $tech_type => $ipa) {
-        $current_tech_price = PublicMarket::price($tech_type);
+        if($tech_type <> 't_bus' && $tech_type <> 't_res')
+            $current_tech_price = PublicMarket::price($tech_type);
+        else // force bus and res tech to have the same price buckets
+            $current_tech_price = min(PublicMarket::price('t_bus'), PublicMarket::price('t_res'));
+        
         if(!$current_tech_price) {
             log_country_message($c->cnum, "No $tech_type tech available on public market so skipping optimal tech calculations");
             continue;

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -91,7 +91,8 @@ function spend_extra_money(&$c, $buying_priorities, $cpref, $money_to_reserve, $
                         unset($optimal_tech_buying_array[$priority_goal][$key]);
                     elseif($max_spend > 10 * $max_tech_price) {
                         // FUTURE: for bus/res, start by buying the one that the country has the least of?
-                        // TODO: cut down on API calls when tech market is empty or too highly priced?
+                        // TODO: cut down on API calls when tech market is empty or too highly priced? might as well for log spam reasons
+                        // have a single prices skipped line with a comma delimited list
                         $total_spent_on_single_tech = PublicMarket::buy_tech($c, $tech_name, $max_spend, $max_tech_price, $tech_point_limit);
                         $max_spend -= $total_spent_on_single_tech; // have to update here for buy_tech() to not overbuy
                         $total_spent_by_step += $total_spent_on_single_tech;

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -642,6 +642,11 @@ function estimate_future_private_market_capacity_for_military_unit($military_uni
 function attempt_to_recycle_bushels_but_avoid_buyout(&$c, $cpref, &$food_price_history) {
     if($cpref->should_demo_attempt_bushel_recycle && $c->govt == 'D' && $c->turns_played >= 300) {
         $food_public_price = PublicMarket::price('m_bu');
+        if(!$food_public_price) {
+            log_country_message($c->cnum, "Did not attempt to recycle bushels because food market is empty!");
+            return false;
+        }
+
         $pm_info = PrivateMarket::getInfo();
         $private_market_bushel_price = $pm_info->sell_price->m_bu;        
         $will_recycle_be_profitable = can_resell_bushels_from_public_market ($private_market_bushel_price, 1, $food_public_price, $max_profitable_public_market_bushel_price);

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -558,17 +558,13 @@ function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_prio
                 usort($optimal_tech_buying_array[$turn_bucket],
                 function ($a, $b) use($rand) { // sort by quantity desc, not price asc - otherwise farmers are likely to buy bus/res before agri! still not perfect, but good enough?
                     return -10 * ($a['q'] <=> $b['q']) // biggest weight by quantity
-                    + ($a['q'] == $b['q'] ? // if quantity is the same
-                        ($a['t'] <=> $b['t'])
-                        : 0)
-/*
                      + ($a['q'] == $b['q'] ? // if quantity is the same
                         (($a['q'] + $rand) % 2 == 1 ? 1 : -1) // 50/50% chance of getting 1 or -1
                         * ($a['t'] <=> $b['t']) // we go through this trouble to get a somewhat random order for bus/res
                         : 0                         
-                     )
-                     */
-                     ;
+                     );
+                     // NOTE: the ordering does not work out as expected with quantity ties, but seems to be random enough
+                     // personally I believe there's a bug in usort()
                 });
             log_country_data($c->cnum, $optimal_tech_buying_array[$turn_bucket], "Results for optimal tech array at $turn_bucket% turn goal:");
         }

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -491,9 +491,9 @@ function get_optimal_tech_buying_array($c, $eligible_techs, $buying_priorities, 
         return $turn_buckets;
     }
 
-    $tech_type_to_ipa = get_ipas_for_tech_purchasing($c, $eligible_techs);
-
     log_country_message($c->cnum, "Creating optimal tech buying array", 'green');
+
+    $tech_type_to_ipa = get_ipas_for_tech_purchasing($c, $eligible_techs);
 
     $optimal_tech_buying_array = [];
 

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -474,8 +474,6 @@ function get_extra_income_affected_by_tech ($c, $tech_type, $rules) {
 
 
 function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_priorities, $max_tech_price, $base_tech_value, $force_all_turn_buckets = false) {
-    // TODO: test changed ai_base calcs (will need to commit)
-
     if($c->protection) {
         log_country_message($c->cnum, 'Not creating optimal tech buying array because country is still under protection');
         return [];

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -554,7 +554,7 @@ function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_prio
             else
                 usort($optimal_tech_buying_array[$turn_bucket],
                 function ($a, $b) { // sort by quantity desc, not price asc - otherwise farmers are likely to buy bus/res before agri! still not perfect, but good enough?
-                    return -1 * ($a['q'] <=> $b['q']); // spaceship!
+                    return -100 * ($a['q'] <=> $b['q']) + ($a['q'] == $b['q'] ? rand(1, 99) : 0); // spaceship! the rand() is there to get a different order for bus/res
                 });
             log_country_data($c->cnum, $optimal_tech_buying_array[$turn_bucket], "Results for optimal tech array at $turn_bucket% turn goal:");
         }

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -558,11 +558,15 @@ function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_prio
                 usort($optimal_tech_buying_array[$turn_bucket],
                 function ($a, $b) use($rand) { // sort by quantity desc, not price asc - otherwise farmers are likely to buy bus/res before agri! still not perfect, but good enough?
                     return -10 * ($a['q'] <=> $b['q']) // biggest weight by quantity
+                    + ($a['t'] <=> $b['t'])
+/*
                      + ($a['q'] == $b['q'] ? // if quantity is the same
                         (($a['q'] + $rand) % 2 == 1 ? 1 : -1) // 50/50% chance of getting 1 or -1
-                        * ($a['t'] < $b['t'] ? 1 : -1) // we go through this trouble to get a somewhat random order for bus/res
-                        : 0 
-                     );
+                        * ($a['t'] <=> $b['t']) // we go through this trouble to get a somewhat random order for bus/res
+                        : 0                         
+                     )
+                     */
+                     ;
                 });
             log_country_data($c->cnum, $optimal_tech_buying_array[$turn_bucket], "Results for optimal tech array at $turn_bucket% turn goal:");
         }

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -474,6 +474,11 @@ function get_extra_income_affected_by_tech ($c, $tech_type, $rules) {
 function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_priorities, $max_tech_price, $base_tech_value, $force_all_turn_buckets = false) {
     // TODO: test changed ai_base calcs (will need to commit)
 
+    if($c->protection) {
+        log_country_message($c->cnum, 'Not creating optimal tech buying array because country is still under protection');
+        return [];
+    }
+
     $turn_buckets = [];
     if($force_all_turn_buckets) {
         for($turn_bucket_num = 10; $turn_bucket_num <= 100; $turn_bucket_num+=10){

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -639,11 +639,11 @@ function attempt_to_recycle_bushels_but_avoid_buyout(&$c, $cpref, &$food_price_h
 
         $pm_info = PrivateMarket::getInfo();
         $private_market_bushel_price = $pm_info->sell_price->m_bu;        
-        $will_recycle_be_profitable = can_resell_bushels_from_public_market ($private_market_bushel_price, 1, $avg_price, $dummy);
+        $will_recycle_be_profitable = can_resell_bushels_from_public_market ($private_market_bushel_price, 1, $food_public_price, $dummy);
 
         if($will_recycle_be_profitable) {
             log_country_message($c->cnum, "Attempting to recycle bushels because it is expected to be profitable and $food_public_price <= average price of $avg_price", 'green');
-            do_public_market_bushel_resell_loop ($c, $avg_price); // don't allow buying above average to hopefully avoid food buyouts
+            do_public_market_bushel_resell_loop ($c, min($private_market_bushel_price - 1, $avg_price)); // don't allow buying above average to hopefully avoid food buyouts
             return true;
         }
         else {

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -91,7 +91,7 @@ function spend_extra_money(&$c, $buying_priorities, $cpref, $money_to_reserve, $
                         unset($optimal_tech_buying_array[$priority_goal][$key]);
                     elseif($max_spend > 10 * $max_tech_price) {
                         // FUTURE: for bus/res, start by buying the one that the country has the least of?
-                        // TODO: cut down on API calls when tech market is empty or too highly priced? might as well for log spam reasons
+                        // FUTURE: cut down on API calls when tech market is empty or too highly priced? might as well for log spam reasons
                         // have a single prices skipped line with a comma delimited list
                         $total_spent_on_single_tech = PublicMarket::buy_tech($c, $tech_name, $max_spend, $max_tech_price, $tech_point_limit);
                         $max_spend -= $total_spent_on_single_tech; // have to update here for buy_tech() to not overbuy

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -621,6 +621,36 @@ function estimate_future_private_market_capacity_for_military_unit($military_uni
 }
 
 
+function attempt_to_recycle_bushels_but_avoid_buyout(&$c, $cpref, &$food_price_history) {
+    if($cpref->should_demo_attempt_bushel_recycle && $c->govt == 'D' && $c->turns_played >= 300) {
+        if($food_price_history === []) // cache this for future calls
+            $food_price_history = get_market_history_food($c->cnum, $cpref);
+
+        $avg_price = floor($food_price_history['avg_price']);
+        $food_public_price = PublicMarket::price('m_bu');
+        if($food_public_price > $avg_price) {
+            log_country_message($c->cnum, "Did not attempt to recycle bushels because current food price $food_public_price is above average price of $avg_price");
+            return false; // don't allow buying above average to hopefully avoid food buyouts
+        }
+
+        $pm_info = PrivateMarket::getInfo();
+        $private_market_bushel_price = $pm_info->sell_price->m_bu;        
+        $will_recycle_be_profitable = can_resell_bushels_from_public_market ($private_market_bushel_price, 1, $avg_price, $dummy);
+
+        if($will_recycle_be_profitable) {
+            log_country_message($c->cnum, "Attempting to recycle bushels because it is expected to be profitable and $food_public_price is below average price of $avg_price");
+            do_public_market_bushel_resell_loop ($c, $avg_price); // don't allow buying above average to hopefully avoid food buyouts
+            return true;
+        }
+        else {
+            log_country_message($c->cnum, "Did not attempt to recycle bushels because current food price $food_public_price >= private price $private_market_bushel_price");
+            return false;
+        }
+    }
+    return false;
+}
+
+
 /*
 NAME: can_resell_bushels_from_public_market
 PURPOSE: checks if current public market bushel price allows for profitable reselling on private market

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -691,7 +691,6 @@ function do_public_market_bushel_resell_loop (&$c, $max_public_market_bushel_pur
 
 		$previous_food = $c->food;
 		$result = PublicMarket::buy($c, ['m_bu' => $max_quantity_to_buy_at_once], ['m_bu' => $current_public_market_bushel_price]);
-		// FUTURE: sometimes see an error here with an unexpected price (1 below last) - expected? taxes?
 		$bushels_purchased_quantity = $c->food - $previous_food;
 		if ($bushels_purchased_quantity == 0) {
 			 // most likely explanation is price changed, so update it

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -558,7 +558,9 @@ function get_optimal_tech_buying_array($c, $rules, $eligible_techs, $buying_prio
                 usort($optimal_tech_buying_array[$turn_bucket],
                 function ($a, $b) use($rand) { // sort by quantity desc, not price asc - otherwise farmers are likely to buy bus/res before agri! still not perfect, but good enough?
                     return -10 * ($a['q'] <=> $b['q']) // biggest weight by quantity
-                    + ($a['t'] <=> $b['t'])
+                    + ($a['q'] == $b['q'] ? // if quantity is the same
+                        ($a['t'] <=> $b['t'])
+                        : 0)
 /*
                      + ($a['q'] == $b['q'] ? // if quantity is the same
                         (($a['q'] + $rand) % 2 == 1 ? 1 : -1) // 50/50% chance of getting 1 or -1

--- a/Selling.php
+++ b/Selling.php
@@ -28,6 +28,23 @@ function emergency_sell_mil_on_pm (&$c, $money_needed) {
 }
 
 
+
+function get_market_history_all_military_units($cpref){
+    $market_history = [];
+
+    $military_units = ['m_tr', 'm_j', 'm_tu', 'm_ta'];
+    $search_result_fields = ['low_price', 'high_price', 'total_units_sold', 'total_sales', 'avg_price', 'no_results'];
+    foreach($military_units as $unit){
+        $market_history_for_unit = get_market_history($unit, $cpref->market_search_look_back_hours);
+        foreach($search_result_fields as $field){
+            $market_history[$unit][$field] = $market_history_for_unit->$field;
+        }
+    }
+
+    return $market_history;
+}
+
+
 // $market_good_name accepts m_tr, food, m_bu, oil, m_oil, bus, t_bus as examples
 function get_market_history($market_good_name, $look_back_hours) {
     $result = ee('market_search', [

--- a/Selling.php
+++ b/Selling.php
@@ -28,7 +28,6 @@ function predict_destock_bushel_sell_price($c, $rules) {
 }
 
 function emergency_sell_mil_on_pm (&$c, $money_needed) {
-    // TODO: test 
     $pm_info = privatemarket::getInfo();
     // prefer to sell jets, then tanks, then troops, than turrets
     $mil_sell_order = ['m_j', 'm_ta', 'm_tr', 'm_tu'];

--- a/Selling.php
+++ b/Selling.php
@@ -33,6 +33,8 @@ function emergency_sell_mil_on_pm (&$c, $money_needed) {
     // prefer to sell jets, then tanks, then troops, than turrets
     $mil_sell_order = ['m_j', 'm_ta', 'm_tr', 'm_tu'];
 
+    log_country_message($c->cnum, "Conducting emergency sell of military on PM to get $money_needed money");
+
     foreach($mil_sell_order as $mil_unit){
         $sell_price = $pm_info->sell_price->$mil_unit;
         $amount_to_sell = min($c->$mil_unit, ceil($money_needed / $sell_price));
@@ -60,14 +62,13 @@ function get_farmer_max_sell_price($c, $cpref, $rules, $server) {
 }
 
 
-
 function get_market_history_all_military_units($cnum, $cpref){
     $market_history = [];
 
     $military_units = ['m_tr', 'm_j', 'm_tu', 'm_ta'];
     $search_result_fields = ['low_price', 'high_price', 'total_units_sold', 'total_sales', 'avg_price', 'no_results'];
     foreach($military_units as $unit){
-        $market_history_for_unit = get_market_history($unit, $cpref->market_search_look_back_hours);
+        $market_history_for_unit = get_market_history($unit, $cpref->get_market_history_look_back_hours());
         foreach($search_result_fields as $field){
             $market_history[$unit][$field] = $market_history_for_unit->$field;
         }
@@ -97,7 +98,7 @@ function get_market_history_tech_internal($cnum, $cpref, $tech_list){
 
     $search_result_fields = ['low_price', 'high_price', 'total_units_sold', 'total_sales', 'avg_price', 'no_results'];
     foreach($tech_list as $unit){
-        $market_history_for_unit = get_market_history($unit, $cpref->market_search_look_back_hours);
+        $market_history_for_unit = get_market_history($unit, $cpref->get_market_history_look_back_hours());
         foreach($search_result_fields as $field){
             $market_history[$unit][$field] = $market_history_for_unit->$field;
         }
@@ -112,7 +113,7 @@ function get_market_history_tech_internal($cnum, $cpref, $tech_list){
 function get_market_history_food($cnum, $cpref){
     $market_history = [];
     $search_result_fields = ['low_price', 'high_price', 'total_units_sold', 'total_sales', 'avg_price', 'no_results'];
-    $market_history_for_unit = get_market_history('food', $cpref->market_search_look_back_hours);
+    $market_history_for_unit = get_market_history('food', $cpref->get_market_history_look_back_hours());
     foreach($search_result_fields as $field){
          $market_history[$field] = $market_history_for_unit->$field;
     }

--- a/Selling.php
+++ b/Selling.php
@@ -2,6 +2,15 @@
 
 namespace EENPC;
 
+
+
+
+function sell_initial_troops_on_turn_0(&$c) {
+    if($c->turns_played == 0 && $c->m_tr > 0)
+        privatemarket::sell_single_good($c, 'm_tr', $c->m_tr);
+}
+
+
 function get_max_demo_bushel_recycle_price($rules) {
     return round($rules->base_pm_food_sell_price / 0.81667); // FUTURE: get max mil tech from game
 }

--- a/Selling.php
+++ b/Selling.php
@@ -19,7 +19,7 @@ function get_max_demo_bushel_recycle_price($rules) {
 function predict_destock_bushel_sell_price($c, $rules) {
     $max_demo_recycle_price = get_max_demo_bushel_recycle_price($rules);
     if($c->govt == "H" or $c->govt == "D")
-        $sell_price = (2 - $c->tax()) * ($max_demo_recycle_price - 2);
+        $sell_price = (2 - $c->tax()) * ($max_demo_recycle_price - 1);
     else
         $sell_price = $max_demo_recycle_price - 3; // if we're stocking, we'll probably have decent mil tech to sell on private at the end
 

--- a/Selling.php
+++ b/Selling.php
@@ -28,8 +28,8 @@ function predict_destock_bushel_sell_price($c, $rules) {
 }
 
 function emergency_sell_mil_on_pm (&$c, $money_needed) {
-    // TODO: test
-    $pm_info = get_pm_info();
+    // TODO: test 
+    $pm_info = privatemarket::getInfo();
     // prefer to sell jets, then tanks, then troops, than turrets
     $mil_sell_order = ['m_j', 'm_ta', 'm_tr', 'm_tu'];
 

--- a/Selling.php
+++ b/Selling.php
@@ -29,6 +29,20 @@ function emergency_sell_mil_on_pm (&$c, $money_needed) {
 
 
 
+function get_farmer_max_sell_price($c, $cpref, $rules, $server) {
+    // this is a bit simple and can lead to a big jump, but 360 turns feels like enough time for prices to stablize
+    // if demand for food truly is high then human players can react as needed
+    if($c->turns_played <= 360)
+        $max_sell_price = $cpref->farmer_max_early_sell_price;
+    else
+        $max_sell_price = $cpref->farmer_max_late_sell_price;  
+
+    log_country_message($c->cnum, "Bushel maximum sell price calculated as $max_sell_price based on preference and turns played");
+    return $max_sell_price;           
+}
+
+
+
 function get_market_history_all_military_units($cnum, $cpref){
     $market_history = [];
 

--- a/Selling.php
+++ b/Selling.php
@@ -29,7 +29,7 @@ function emergency_sell_mil_on_pm (&$c, $money_needed) {
 
 
 
-function get_market_history_all_military_units($cpref){
+function get_market_history_all_military_units($cnum, $cpref){
     $market_history = [];
 
     $military_units = ['m_tr', 'm_j', 'm_tu', 'm_ta'];
@@ -39,6 +39,7 @@ function get_market_history_all_military_units($cpref){
         foreach($search_result_fields as $field){
             $market_history[$unit][$field] = $market_history_for_unit->$field;
         }
+        log_country_data($cnum, $market_history[$unit], "Market history for $unit:");
     }
 
     return $market_history;
@@ -55,7 +56,148 @@ function get_market_history($market_good_name, $look_back_hours) {
     return $result;
 }
 
-// high price, avg price, sales, current price, random
 
 
 
+
+// makes all elements of the array into whole numbers that add up to $target_sum
+function normalize_array_for_selling($cnum, &$score_array, $target_sum, $preferred_key_for_remainder = null) {
+    if($preferred_key_for_remainder and !isset($score_array[$preferred_key_for_remainder])) {
+        log_error_message(999, $cnum, 'normalize_array_for_selling(): $preferred_key_for_remainder is not a key of the array');
+        $preferred_key_for_remainder = null;
+    }
+
+    $current_sum = array_sum($score_array);
+    foreach($score_array as $key => $weight)
+        $score_array[$key] = ($current_sum == 0 ? 1 : floor($weight * $target_sum / $current_sum));
+
+    $leftovers = $target_sum - array_sum($score_array);
+    if($preferred_key_for_remainder)
+        $score_array[$preferred_key_for_remainder] += $leftovers;
+    else
+        $score_array[key($score_array)] += $leftovers; // take some arbitrary key
+
+    return true;
+}
+
+
+// TODO: add get_market_history_all_tech
+// TODO: add get_tech_from_production_algorithm
+
+function set_indy_from_production_algorithm(&$c, $military_unit_price_history, $cpref, $checkDPA = false)
+{
+    // produce 100% turrets if checked in the first 150 turns because there's very little demand for anything else
+    // FUTURE: 150 is a made up number that could be changed to something better
+    if ($c->turns_played < 150) { 
+        $new_indy_production['pro_tu'] = 100;
+    }
+    else { // not the first 150 turns
+        // for now, 400 indy's worth of production with 1% min and 5% max
+        // 200 was too low - maybe because of OOF and OOM events?
+        $spy = max(1, min(5, round(400 / ($c->b_indy + 1))));
+
+        $production_score = [];
+        $production_factor_per_unit = [
+            'm_tr'  => 1.86,
+            'm_j'   => 1.86,
+            'm_tu'  => 1.86,
+            'm_ta'  => 0.4
+        ];
+
+        // for CURRENT_PRICE
+        $default_current_prices = [
+            'm_tr'  => 120,
+            'm_j'   => 160,
+            'm_tu'  => 200,
+            'm_ta'  => 480
+        ];
+
+        // for HIGH_PRICE, AVG_PRICE, and SALES
+        $default_historical_prices = [
+            'm_tr'  => 10,
+            'm_j'   => 60,
+            'm_tu'  => 200,
+            'm_ta'  => 40
+        ];
+       
+
+        // global $market; // why?
+
+        log_country_message($c->cnum, "Setting indy production using algorithm $cpref->production_algorithm", 'green');       
+
+        //out_data($military_unit_price_history);
+
+        // $military_unit_price_history[$unit] elements can be null if there were no recent sales
+        $number_of_units_with_no_data = 0;
+        foreach($production_factor_per_unit as $unit => $units_produced) {
+            if($cpref->production_algorithm == "SALES") {
+                $default_price = $default_historical_prices[$unit];
+                $price = isset($military_unit_price_history[$unit]['total_sales']) ? $military_unit_price_history[$unit]['total_sales'] : $default_price;
+            }
+            elseif($cpref->production_algorithm == "HIGH_PRICE") {   
+                $default_price = $default_historical_prices[$unit];
+                $price = isset($military_unit_price_history[$unit]['high_price']) ? $military_unit_price_history[$unit]['high_price'] : $default_price;
+            }
+            elseif($cpref->production_algorithm == "AVG_PRICE") {  
+                $default_price = $default_historical_prices[$unit]; 
+                $price = isset($military_unit_price_history[$unit]['avg_price']) ? $military_unit_price_history[$unit]['avg_price'] : $default_price;
+            }
+            elseif($cpref->production_algorithm == "CURRENT_PRICE") {   
+                $default_price = $default_current_prices[$unit];
+                $market_price = PublicMarket::price($unit);
+                $price = $market_price ? $market_price : $default_price;
+            }
+            else { // RANDOM or invalid value
+                $price = mt_rand(1, 1000) / $units_produced;
+
+                if($cpref->production_algorithm <> "RANDOM") // doesn't matter if this gets shown 4 times
+                    log_error_message(999, $c->cnum, "set_indy_from_production_algorithm(): invalid value for production algorithm: $cpref->production_algorithm");
+            }
+            $unit_score = $units_produced * $price;
+            $production_score[$unit] = $unit_score;
+            log_country_message($c->cnum, "Score for unit $unit is $unit_score before normalization");
+
+            if($default_price == $price)
+                $number_of_units_with_no_data++;
+        }
+
+        if($number_of_units_with_no_data == 4) { // we will rarely get false positives with this approach, but whatever
+            log_country_message($c->cnum, "Detected no market data so using default values that favor turret production");
+            $production_score['m_tr'] = 1;
+            $production_score['m_j'] = 13;           
+            $production_score['m_tu'] = 85;
+            $production_score['m_ta'] = 1;
+        }
+       
+        // remove jets if we're checking DPA and it's too low
+        if ($checkDPA) {
+            $target = $c->defPerAcreTarget();
+            if ($c->defPerAcre() < $target) {
+                //below def target, don't make jets
+                unset($production_score['m_j']);
+                log_country_message($c->cnum, "Setting jet production to 0% because DPAT isn't met");
+            }
+        }
+
+        // make everything an integer and make it all sum to 100%
+        log_country_message($c->cnum, "Normalizing indy production scores so they sum to 100");
+        normalize_array_for_selling($c->cnum, $production_score, 100 - $spy, 'm_tu');
+
+        // basically just remapping m_* keys to pro_* keys
+        $new_indy_production = [
+            'pro_spy' => $spy,
+            'pro_tr'  => $production_score['m_tr'],
+            'pro_j'   => $production_score['m_j'],
+            'pro_tu'  => $production_score['m_tu'],
+            'pro_ta'  => $production_score['m_ta']
+        ];
+
+        $protext = null;
+        foreach ($new_indy_production as $k => $s) {
+            $protext .= $s.' '.$k.' ';
+        }
+        //log_country_message($c->cnum, "--- Indy Scoring: ".$protext);
+    }
+
+    $c->setIndy($new_indy_production);
+}//end set_indy_from_production_algorithm()

--- a/Selling.php
+++ b/Selling.php
@@ -142,7 +142,7 @@ $high_price_score_array, $no_market_history_score_array, $current_price_score_ar
         foreach(array_keys($price_array) as $unit) {
             $unit_score = array_pop($high_price_score_array);
             $production_score[$unit] = $unit_score;
-            log_country_message($cnum, "New score for $unit is $unit_score");
+            //log_country_message($cnum, "New score for $unit is $unit_score");
         }
     } // end HIGH_PRICE
     elseif($cpref->production_algorithm == "CURRENT_PRICE") {   
@@ -160,7 +160,7 @@ $high_price_score_array, $no_market_history_score_array, $current_price_score_ar
         foreach(array_keys($price_array) as $unit) {
             $unit_score = array_pop($current_price_score_array);
             $production_score[$unit] = $unit_score;
-            log_country_message($cnum, "New score for $unit is $unit_score");
+            //log_country_message($cnum, "New score for $unit is $unit_score");
         }
     } // end CURRENT_PRICE
     elseif($cpref->production_algorithm == "SALES") {

--- a/Selling.php
+++ b/Selling.php
@@ -30,7 +30,7 @@ function emergency_sell_mil_on_pm (&$c, $money_needed) {
 
 // $market_good_name accepts m_tr, food, m_bu, oil, m_oil, bus, t_bus as examples
 function get_market_history($market_good_name, $look_back_hours) {
-    $result = ee('get_optimal_tech_buying_info', [
+    $result = ee('market_search', [
         'good' => $market_good_name,
         'look_back_hours' => $look_back_hours
     ]);

--- a/Selling.php
+++ b/Selling.php
@@ -403,3 +403,16 @@ function get_tpt_split_from_production_algorithm(&$c, $tech_price_history, $cpre
     // no need for proper normalization here. it will have to keep getting normalized because tpt can change as the country plays turns
     return $production_score;
 }//end get_tpt_split_from_production_algorithm()
+
+
+
+function recall_goods()
+{
+    return ee('market_recall', ['type' => 'GOODS']);
+}//end recall_goods()
+
+
+function recall_tech()
+{
+    return ee('market_recall', ['type' => 'TECH']);
+}//end recall_tech()

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -100,7 +100,7 @@ function get_farmer_min_sell_price($c, $cpref, $rules, $server, $min_cash_to_cal
 
             $military_unit_end_value = round($unit_nw * $military_end_dpnw, 2);
 
-            $military_unit_exp_per_turn = get_approx_expense_per_turn_for_mil_unit($unit, $unit_nw, 40, $c->govt, $c->networth, $c->pt_mil, $c->expenses_mil);
+            $military_unit_exp_per_turn = get_approx_expense_per_turn_for_mil_unit($unit, $unit_nw, $bushel_end_sell_price, $c->govt, $c->networth, $c->pt_mil, $c->expenses_mil);
             $military_unit_expenses = round($military_unit_exp_per_turn * ($c->turns_stored + $server_new_turns_remaining), 2);
            
             $sell_break_even_price = 1 + ceil($bushel_end_sell_price * ($c->tax() * $military_unit_price + $military_unit_expenses) / ((2 - $c->tax()) * $military_unit_end_value));
@@ -240,7 +240,8 @@ function get_stockpiling_weights_and_adjustments (&$stockpiling_weights, &$stock
             $military_unit_sell_price = round($unit_nw * $military_end_dpnw, 2);
             $military_unit_weight = round($max_loss * $military_unit_sell_price / (10 * $max_loss * (100 - $max_loss)), 4);
             // $c->expenses_mil only gets updated by the advisor, but should be fine because this code is called early on during turns
-            $military_unit_exp_per_turn = get_approx_expense_per_turn_for_mil_unit($unit, $unit_nw, 40, $c->govt, $c->networth, $c->pt_mil, $c->expenses_mil);
+            // 45 is just a guess... not clear what to do here
+            $military_unit_exp_per_turn = get_approx_expense_per_turn_for_mil_unit($unit, $unit_nw, 45, $c->govt, $c->networth, $c->pt_mil, $c->expenses_mil);
             $exp = round($military_unit_exp_per_turn * ($c->turns_stored + $server_new_turns_remaining), 2);
             $military_unit_adjustment = $exp - $military_unit_sell_price;
 

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -119,7 +119,8 @@ function get_farmer_min_sell_price($c, $cpref, $rules, $server, $min_cash_to_cal
         $military_unit_end_value = round(0.5 * $military_end_dpnw, 2);
         $military_unit_price = $pm_info->buy_price->m_tr;
         // expenses make the unit "cost" more
-        $military_unit_expenses = round(0.01 * $c->pt_mil * $unit_exp['m_tr'] * $server_new_turns_remaining, 2);
+        $military_unit_exp_per_turn = get_approx_expense_per_turn_for_mil_unit('m_tr', 0.5, $bushel_end_sell_price, $c->govt, $c->networth, $c->pt_mil, $c->expenses_mil);
+        $military_unit_expenses = round($military_unit_exp_per_turn * ($c->turns_stored + $server_new_turns_remaining), 2);
        
         $sell_break_even_price = 1 + ceil($bushel_end_sell_price * ($military_unit_price + $military_unit_expenses) / ((2 - $c->tax()) * $military_unit_end_value));
         $bushel_break_even_sell_prices['pm_tr'] = $sell_break_even_price;

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -5,14 +5,14 @@ namespace EENPC;
 
 function stash_excess_bushels_on_public_if_needed(&$c, $rules, $max_sell_price = null) {
     // 0.001 is for decay
-    $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * min(0, ($c->foodnet + 0.001 * $c->food)));
+    $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * floor(min(0, ($c->foodnet + 0.001 * $c->food))));
 
     if($excess_bushels > 3500000) {
         if(!food_and_money_for_turns($c, 1, 0, false, true)) // if false then we can't run a turn without hitting OOF
             return false; // FUTURE: it is unfortunate to return a turn result or false
 
         // shouldn't be a big deal if we sell some bushels to fund running a turn, but just in case do the calc again:
-        $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * ($c->foodnet + 0.001 * $c->food));
+        $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * floor(min(0, ($c->foodnet + 0.001 * $c->food))));
 
         $quantity = ['m_bu' => $excess_bushels];
         if($max_sell_price) {

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -92,7 +92,8 @@ function get_farmer_min_sell_price($c, $cpref, $rules, $server, $min_cash_to_cal
 
         // public market military
         $military_end_dpnw = 2025 * 0.01 * ($c->govt == "H" ? 0.8 : 1.0) * $c->pt_mil / 6.5; // use what we can get on PM
-        $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003]; // TODO: add NW modifier
+        $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003];
+        // TODO: add NW modifier - should just call function
         $unit_nw = ['m_tr'=>0.5, 'm_j' => 0.6, 'm_tu' => 0.6, 'm_ta' => 2.0];
         foreach($unit_nw as $unit => $unit_nw) {     
             $military_unit_price = PublicMarket::price($unit);
@@ -237,7 +238,7 @@ function get_stockpiling_weights_and_adjustments (&$stockpiling_weights, &$stock
         $military_end_dpnw = $cpref->final_dpnw_for_stocking_calcs * 0.01 * $c->pt_mil * ($c->govt == "H" ? 0.8 : 1.0);
         $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003];
         $exp_cost_mod = ($c->govt == "T" ? 0.9 : 1) * (1 + $c->networth / 200000000); // this applies to food but shouldn't, but I can live with that
-        // TODO: could a country buy so much mil that it ends up not making money per turn?
+        // FUTURE: could a country buy so much mil that it ends up not making money per turn?
         $unit_nw = ['m_tr'=>0.5, 'm_j' => 0.6, 'm_tu' => 0.6, 'm_ta' => 2.0];
         foreach($unit_nw as $unit => $unit_nw) {
             $military_unit_sell_price = round($unit_nw * $military_end_dpnw, 2);

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -234,7 +234,7 @@ function get_stockpiling_weights_and_adjustments (&$stockpiling_weights, &$stock
 
     if($allow_military){
         $server_new_turns_remaining = floor(($server->reset_end - time()) / $server->turn_rate); // FUTURE: function?
-        $military_end_dpnw = 2025 * 0.01 * ($c->govt == "H" ? 0.8 : 1.0) * $c->pt_mil / 6.5; // use what we can get on PM
+        $military_end_dpnw = $cpref->final_dpnw_for_stocking_calcs * 0.01 * $c->pt_mil * ($c->govt == "H" ? 0.8 : 1.0);
         $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003];
         $exp_cost_mod = ($c->govt == "T" ? 0.9 : 1) * (1 + $c->networth / 200000000); // this applies to food but shouldn't, but I can live with that
         // TODO: could a country buy so much mil that it ends up not making money per turn?

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -24,7 +24,7 @@ function stash_excess_bushels_on_public_if_needed(&$c, $rules, $max_sell_price =
             log_country_message($c->cnum, "Selling excess $excess_bushels bushels at high prices to stash them away");
         }
         $res = PublicMarket::sell($c, $quantity, $price); 
-        update_c($c, $res);
+        update_c($c, $res); // TODO: return the result and don't do update_c? can't log to turn actions with this method
         return true; // FUTURE: catch fails?
     }
     return false;

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -92,17 +92,16 @@ function get_farmer_min_sell_price($c, $cpref, $rules, $server, $min_cash_to_cal
 
         // public market military
         $military_end_dpnw = 2025 * 0.01 * ($c->govt == "H" ? 0.8 : 1.0) * $c->pt_mil / 6.5; // use what we can get on PM
-        $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003];
-        // TODO: add NW modifier - should just call function
         $unit_nw = ['m_tr'=>0.5, 'm_j' => 0.6, 'm_tu' => 0.6, 'm_ta' => 2.0];
         foreach($unit_nw as $unit => $unit_nw) {     
             $military_unit_price = PublicMarket::price($unit);
             if(!$military_unit_price)
                 continue;
 
-            $military_unit_end_value = round($unit_nw * $military_end_dpnw, 2);            
-            // expenses make the unit "cost" more
-            $military_unit_expenses = round(0.01 * $c->pt_mil * $unit_exp[$unit] * $server_new_turns_remaining, 2);
+            $military_unit_end_value = round($unit_nw * $military_end_dpnw, 2);
+
+            $military_unit_exp_per_turn = get_approx_expense_per_turn_for_mil_unit($unit, $unit_nw, 40, $c->govt, $c->networth, $c->pt_mil, $c->expenses_mil);
+            $military_unit_expenses = round($military_unit_exp_per_turn * ($c->turns_stored + $server_new_turns_remaining), 2);
            
             $sell_break_even_price = 1 + ceil($bushel_end_sell_price * ($c->tax() * $military_unit_price + $military_unit_expenses) / ((2 - $c->tax()) * $military_unit_end_value));
             $bushel_break_even_sell_prices[$unit] = $sell_break_even_price;
@@ -172,7 +171,6 @@ function is_country_expected_to_exceed_target_cash_during_turns($c, $target_cash
 
 
 
-
 function get_stockpiling_weights_and_adjustments (&$stockpiling_weights, &$stockpiling_adjustments, $c, $server, $rules, $cpref, $min_cash_to_calc, $allow_bushels, $allow_tech, $allow_military) {
     $max_loss = $cpref->max_stockpiling_loss_percent;
     $stockpiling_weights = [];
@@ -236,15 +234,14 @@ function get_stockpiling_weights_and_adjustments (&$stockpiling_weights, &$stock
     if($allow_military){
         $server_new_turns_remaining = floor(($server->reset_end - time()) / $server->turn_rate); // FUTURE: function?
         $military_end_dpnw = $cpref->final_dpnw_for_stocking_calcs * 0.01 * $c->pt_mil * ($c->govt == "H" ? 0.8 : 1.0);
-        $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003];
-        $exp_cost_mod = ($c->govt == "T" ? 0.9 : 1) * (1 + $c->networth / 200000000); // this applies to food but shouldn't, but I can live with that
         // FUTURE: could a country buy so much mil that it ends up not making money per turn?
         $unit_nw = ['m_tr'=>0.5, 'm_j' => 0.6, 'm_tu' => 0.6, 'm_ta' => 2.0];
         foreach($unit_nw as $unit => $unit_nw) {
             $military_unit_sell_price = round($unit_nw * $military_end_dpnw, 2);
             $military_unit_weight = round($max_loss * $military_unit_sell_price / (10 * $max_loss * (100 - $max_loss)), 4);
-            // expenses make the unit "cost" more
-            $exp = round(0.01 * $c->pt_mil * $exp_cost_mod * $unit_exp[$unit] * ($c->turns_stored + $server_new_turns_remaining), 2); // assumes no MBs
+            // $c->expenses_mil only gets updated by the advisor, but should be fine because this code is called early on during turns
+            $military_unit_exp_per_turn = get_approx_expense_per_turn_for_mil_unit($unit, $unit_nw, 40, $c->govt, $c->networth, $c->pt_mil, $c->expenses_mil);
+            $exp = round($military_unit_exp_per_turn * ($c->turns_stored + $server_new_turns_remaining), 2);
             $military_unit_adjustment = $exp - $military_unit_sell_price;
 
             $stockpiling_weights[$unit] = $military_unit_weight;
@@ -262,6 +259,17 @@ function get_stockpiling_weights_and_adjustments (&$stockpiling_weights, &$stock
     }
 
     return true;
+}
+
+
+function get_approx_expense_per_turn_for_mil_unit ($unit, $unit_nw, $food_price, $govt, $networth, $pt_mil, $current_expenses_mil) {
+    $unit_base_exp_money = ['m_tr' => 0.11,'m_j' => 0.14,'m_tu' => 0.18,'m_ta' => 0.57];
+    $unit_base_exp_food = ['m_tr' => 0.001,'m_j' => 0.001,'m_tu' => 0.001,'m_ta' => 0.003];
+
+    // assumes no military bases
+    return 0.01 * $pt_mil * ($govt == "T" ? 0.9 : 1) * (1 + $networth / 200000000) * $unit_base_exp_money[$unit] // money
+    + $food_price * $unit_base_exp_food[$unit] // food
+    + $current_expenses_mil * (-1 + (1 + (($unit_nw + $networth) / 200000000)) / (1 + $networth / 200000000)); // expenses increase because NW goes up
 }
 
 

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -235,14 +235,15 @@ function get_stockpiling_weights_and_adjustments (&$stockpiling_weights, &$stock
     if($allow_military){
         $server_new_turns_remaining = floor(($server->reset_end - time()) / $server->turn_rate); // FUTURE: function?
         $military_end_dpnw = 2025 * 0.01 * ($c->govt == "H" ? 0.8 : 1.0) * $c->pt_mil / 6.5; // use what we can get on PM
-        $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003]; // TODO: add NW modifier
+        $unit_exp = ['m_tr' => 0.11 + 40 * 0.001,'m_j' => 0.14 + 40 * 0.001,'m_tu' => 0.18 + 40 * 0.001,'m_ta' => 0.57 + 40 * 0.003];
+        $exp_cost_mod = ($c->govt == "T" ? 0.9 : 1) * (1 + $c->networth / 200000000); // this applies to food but shouldn't, but I can live with that
         // TODO: add tyranny bonus?
         $unit_nw = ['m_tr'=>0.5, 'm_j' => 0.6, 'm_tu' => 0.6, 'm_ta' => 2.0];
         foreach($unit_nw as $unit => $unit_nw) {
             $military_unit_sell_price = round($unit_nw * $military_end_dpnw, 2);
             $military_unit_weight = round($max_loss * $military_unit_sell_price / (10 * $max_loss * (100 - $max_loss)), 4);
             // expenses make the unit "cost" more
-            $exp = round(0.01 * $c->pt_mil * $unit_exp[$unit] * ($c->turns_stored + $server_new_turns_remaining), 2);
+            $exp = round(0.01 * $c->pt_mil * $exp_cost_mod * $unit_exp[$unit] * ($c->turns_stored + $server_new_turns_remaining), 2); // assumes no MBs
             $military_unit_adjustment = $exp - $military_unit_sell_price;
 
             $stockpiling_weights[$unit] = $military_unit_weight;

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -151,7 +151,7 @@ function casher_get_buying_priorities ($cnum, $buying_schedule) {
             ['type'=>'NWPA','goal'=>100]
         ];
     }
-    elseif($buying_schedule == 1) { // heavy teach
+    elseif($buying_schedule == 1) { // heavy tech
         $buying_priorities = [
             ['type'=>'DPA','goal'=>1],
             ['type'=>'INCOME_TECHS','goal'=>100],

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -64,7 +64,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         }
 
         $action_and_turns_used = update_c($c, $result);
-        update_intended_action_array($turn_action_counts, $action_and_turns_used);
+        update_turn_action_array($turn_action_counts, $action_and_turns_used);
 
         if (!$c->turns % 5) {                   //Grab new copy every 5 turns
             $c->updateMain(); //we probably don't need to do this *EVERY* turn
@@ -106,7 +106,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         // don't see a strong reason to sell excess bushels at this step
     }
 
-    $c->countryStats(CASHER); // FUTURE: implement? , casherGoals($c));
+    $c->countryStats(CASHER);
     return $c;
 }//end play_casher_strat()
 

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -51,6 +51,8 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition)
 
     stash_excess_bushels_on_public_if_needed($c, $rules);
 
+    attempt_to_recycle_bushels_but_avoid_buyout($c, $cpref, $food_price_history);
+
     $turns_played_for_last_spend_money_attempt = 0;
     while ($c->turns > 0) {
         $result = play_casher_turn($c, $is_allowed_to_mass_explore);

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -10,6 +10,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     //out_data($main);          //output the main data
     $c = get_advisor();     //c as in country! (get the advisor)
     //out_data($c) && exit;             //ouput the advisor data
+    log_static_cpref_on_turn_0 ($c, $cpref); // TODO: test
 
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
     log_country_message($cnum, "Bus: {$c->pt_bus}%; Res: {$c->pt_res}%; Mil: {$c->pt_mil}%; Weap: {$c->pt_weap}%");
@@ -61,7 +62,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     
     $turns_played_for_last_spend_money_attempt = 0;
     while ($c->turns > 0) {
-        $result = play_casher_turn($c, $is_allowed_to_mass_explore);
+        $result = play_casher_turn($c, $cpref, $is_allowed_to_mass_explore);
         if ($result === false) {  //UNEXPECTED RETURN VALUE
             $c = get_advisor();     //UPDATE EVERYTHING
             continue;
@@ -115,9 +116,9 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
 }//end play_casher_strat()
 
 
-function play_casher_turn(&$c, $is_allowed_to_mass_explore)
+function play_casher_turn(&$c, $cpref, $is_allowed_to_mass_explore)
 {
-    $target_bpt = 65;
+    $target_bpt = $cpref->initial_bpt_target;
     global $turnsleep;
     usleep($turnsleep);
     //log_country_message($c->cnum, $main->turns . ' turns left');

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -17,7 +17,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     $c->setIndy('pro_spy');
 
     if ($c->m_spy > 10000) {
-        Allies::fill('spy');
+        Allies::fill($cpref, 'spy');
     }
 
     casher_switch_government_if_needed($c);
@@ -75,7 +75,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }
 
-        $hold = food_management($c);
+        $hold = food_management($c, $cpref);
         if ($hold) {
             $exit_condition = 'WAIT_FOR_PUBLIC_MARKET_FOOD';
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -9,8 +9,11 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     //$main = get_main();     //get the basic stats
     //out_data($main);          //output the main data
     $c = get_advisor();     //c as in country! (get the advisor)
+
+    // FUTURE: cash when explore is no longer worth it
+
     //out_data($c) && exit;             //ouput the advisor data
-    log_static_cpref_on_turn_0 ($c, $cpref); // TODO: test
+    log_static_cpref_on_turn_0 ($c, $cpref);
 
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
     log_country_message($cnum, "Bus: {$c->pt_bus}%; Res: {$c->pt_res}%; Mil: {$c->pt_mil}%; Weap: {$c->pt_weap}%");
@@ -37,8 +40,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     // log useful information about country state
     log_country_message($cnum, $c->turns.' turns left');
     //log_country_message($cnum, 'Explore Rate: '.$c->explore_rate.'; Min Rate: '.$c->explore_min);
-    //$pm_info = get_pm_info(); //get the PM info
-    //out_data($pm_info);       //output the PM info
+
     //$market_info = get_market_info(); //get the Public Market info
     //out_data($market_info);       //output the PM info
 

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -63,7 +63,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition)
             $c->updateMain(); //we probably don't need to do this *EVERY* turn
         }
 
-        $hold = money_management($c, $rules->max_possible_market_sell);
+        $hold = money_management($c, $rules->max_possible_market_sell, $cpref);
         if ($hold) {
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }

--- a/country_functions.php
+++ b/country_functions.php
@@ -420,7 +420,7 @@ function defend_self(&$c, $reserve_cash = 50000, $dpnwMax = 380)
 
 function sell_max_military(&$c, $server_max_possible_market_sell, $cpref, $allow_average_prices = false, $avg_market_prices = [])
 {
-    if($allow_average_prices and $avg_market_prices === []) {
+    if($allow_average_prices && empty($avg_market_prices)) {
         log_error_message(999, $c->cnum, 'sell_max_military() allowed average price selling but $avg_market_prices was empty');
         $allow_average_prices = false;
     }

--- a/country_functions.php
+++ b/country_functions.php
@@ -457,7 +457,7 @@ function sell_max_military(&$c, $server_max_possible_market_sell, $cpref, $allow
         } else {
             $max         = $c->goodsStuck($key) ? 0.99 : $rmax; //undercut if we have goods stuck
             // there's a random chance to sell based on market average prices instead of current prices
-            $use_avg_price = ($allow_average_prices and mt_rand(1, 100) <= $cpref->chance_to_sell_based_on_avg_price) ? true : false;
+            $use_avg_price = ($allow_average_prices && $cpref->get_sell_price_method(false) == 'AVG') ? true : false;
             
             if ($use_avg_price and $avg_price) { // use average price and average price exists
                 $price[$key] = floor($avg_price * Math::purebell($rmin, $max, $rstddev, $rstep));

--- a/country_functions.php
+++ b/country_functions.php
@@ -321,7 +321,7 @@ function food_management(&$c, $cpref)
         log_error_message(1002, $c->cnum, "We're too poor to buy food! Sell 1/10 of our military");
         sell_all_military($c, 1 / 10);     //sell 1/4 of our military
         $c = get_advisor();     //UPDATE EVERYTHING
-        return food_management($c); //RECURSION!
+        return food_management($c, $cpref); //RECURSION!
     }
 
     log_country_message($c->cnum, 'We have exhausted all food options. Valar Morguhlis.');

--- a/country_functions.php
+++ b/country_functions.php
@@ -10,11 +10,11 @@ function is_country_allowed_to_mass_explore($c, $cpref) {
         return false;
     }
     elseif($c->govt == "R" and $c->land > $cpref->mass_explore_stop_acreage_rep) {
-        log_country_message($c->cnum, "Country is not allowed to mass explore because it is a rep with more than 10000 acres on a non-clan server");
+        log_country_message($c->cnum, "Country is not allowed to mass explore because it is a rep with more than $cpref->mass_explore_stop_acreage_rep acres on a non-clan server");
         return false;
     }
     elseif($c->govt <> "R" and $c->land > $cpref->mass_explore_stop_acreage_non_rep) {
-        log_country_message($c->cnum, "Country is not allowed to mass explore because it is a non-rep with more than 8200 acres on a non-clan server");
+        log_country_message($c->cnum, "Country is not allowed to mass explore because it is a non-rep with more than $cpref->mass_explore_stop_acreage_non_rep acres on a non-clan server");
         return false;
     }
     else {
@@ -224,7 +224,7 @@ function money_management(&$c, $server_max_possible_market_sell, $cpref)
 }//end money_management()
 
 
-function food_management(&$c)
+function food_management(&$c, $cpref)
 {
     //RETURNS WHETHER TO HOLD TURNS OR NOT
     $reserve = max(130, $c->turns);
@@ -246,13 +246,15 @@ function food_management(&$c)
         $turns_of_food = $foodloss * $turns_buy;
         $market_price  = PublicMarket::price('m_bu');
 
-        if($market_price >= 100 && $c->turns_stored < 30) { // FUTURE: this isn't really any good, but it's better than nothing
+        // FUTURE: 30 should be a cpref? or just redesign entirely?
+        if($market_price > $cpref->max_bushel_buy_price_with_low_stored_turns && $c->turns_stored < 30) { // FUTURE: this isn't really any good, but it's better than nothing
             log_country_message($c->cnum, "Public market food is too expensive at $market_price; hold turns for now, and wait for food on MKT.");
             return true;
         }
 
         //log_country_message($c->cnum, "Market Price: " . $market_price);
-        if ($c->food < $turns_of_food && $c->money > $turns_of_food * $market_price * $c->tax() && $c->money - $turns_of_food * $market_price * $c->tax() + $c->income * $turns_buy > 0) { //losing food, less than turns_buy turns left, AND have the money to buy it
+        //losing food, less than turns_buy turns left, AND have the money to buy it
+        if ($c->food < $turns_of_food && $c->money > $turns_of_food * $market_price * $c->tax() && $c->money - $turns_of_food * $market_price * $c->tax() + $c->income * $turns_buy > 0) {
             $quantity = min($foodloss * $turns_buy, PublicMarket::available('m_bu'));
             // log_country_message($c->cnum, 
             //     "--- FOOD:  - Buy Public ".str_pad('('.$turns_buy, 17, ' ', STR_PAD_LEFT).

--- a/country_functions.php
+++ b/country_functions.php
@@ -106,7 +106,6 @@ function has_money_for_turns($number_of_turns_to_play, $money, $incoming_money_p
 // tries to buy the requested food within the budget
 // stops buying food if it detects that prices are too high
 function buy_full_food_quantity_if_possible(&$c, $food_needed, $max_food_price_to_buy, $money_to_reserve, $purchase_attempt_number = 1) {
-    // FUTURE: consider private market as well (express might have cheaper food than public)
     if ($food_needed <= 0) {// quit because we bought all of the food we needed
         return true;
     }
@@ -206,6 +205,12 @@ function money_management(&$c, $server_max_possible_market_sell, $cpref)
 {
     while (turns_of_money($c) < 4) {
         //$foodloss = -1 * $c->foodnet;
+
+        // TODO:
+        /*
+                $action_and_turns_used = update_c($c, $result);
+        update_turn_action_array($turn_action_counts, $action_and_turns_used);
+        */
 
         if ($c->turns_stored <= 30 && total_cansell_military($c, $server_max_possible_market_sell) > 7500) {
             log_country_message($c->cnum, "Selling max military, and holding turns.");

--- a/country_functions.php
+++ b/country_functions.php
@@ -450,8 +450,9 @@ function sell_max_military(&$c, $server_max_possible_market_sell)
             );
         }
 
+        // FUTURE: better to hold military?
         if ($price[$key] > 0 && $price[$key] * $c->tax() <= $pm_info->sell_price->$key) {
-            //log_country_message($c->cnum, "Public is too cheap for $key, sell on PM");
+            log_country_message($c->cnum, "Public is too cheap for $key, sell on PM");
             sell_cheap_units($c, $key, 0.5);
             $price[$key]    = 0;
             $quantity[$key] = 0;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -86,7 +86,7 @@ class cpref
 
 
     private function get_purchase_schedule_number() {
-        $unique_schedule_count = ($this->strat == 'C' or $this->strat == 'F' ? 4 : 1);
+        $unique_schedule_count = ($this->strat == "C" or $this->strat == "F" ? 4 : 1);
         // indies and techers only have a single purchase schedule because they either buy mil or tech
         // rainbow doesn't use purchase schedules as of 20210409
         return $this->decode_bot_secret(2) % $unique_schedule_count;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -80,7 +80,7 @@ class cpref
 
 
     private function get_min_perc_teching_turns() {
-        return 10 + round($this->decode_bot_secret(3) / 25); // between 10% and 50%, fine if not completely even probabilities on edges
+        return 20 + round($this->decode_bot_secret(3) / 33); // between 20% and 50%, fine if not completely even probabilities on edges
     }
 
 

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -60,6 +60,7 @@ class cpref
         $this->tech_max_purchase_price = 9999;     
         // techers probably need to buy everything off PM, but other strats can likely skip turrets
         $this->final_dpnw_for_stocking_calcs = ($this->strat == "T" ? (2025 / 6.5) : (3*144+588+2.5*192)/(1.5+2+0.6*2.5));
+        $this->should_demo_attempt_bushel_recycle = true;
 
         // selling
         $this->production_algorithm = $this->get_production_algorithm();  

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -48,8 +48,6 @@ class cpref
         $this->spend_extra_money_cooldown_turns = ($this->strat == "C" ? 5 : 7);
         $this->max_stockpiling_loss_percent = 60; // must be > 0
 
-        // TODO: calc net factor for mil expenses
-
         $this->earliest_destocking_start_time = $this->get_earliest_destocking_start_time();
 
     }//end __construct()

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -37,7 +37,7 @@ class cpref
         $this->gdi = $cpref_file->gdi;
         // end personality file issue
 
-        $this->market_search_look_back_hours = 1; // TODO: random, vary by server length
+        $this->market_search_look_back_hours = 2; // TODO: random, vary by server length
         $this->mass_explore_stop_acreage_rep = ($this->is_clan_server ? 99999 : 10000);
         $this->mass_explore_stop_acreage_non_rep = ($this->is_clan_server ? 99999 : 8200);        
         $this->base_inherent_value_for_tech = 700;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -147,7 +147,7 @@ class cpref
             $static_prefs[] = "min_perc_teching_turns";
         }
 
-        if($$this->strat == 'F') {
+        if($this->strat == 'F') {
             $static_prefs[] = "farmer_max_early_sell_price";
             $static_prefs[] = "farmer_max_late_sell_price";        
         }

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -82,32 +82,40 @@ class cpref
 
 
     private function get_min_perc_teching_turns() {
-        return 20 + round($this->decode_bot_secret(3) / 33); // between 20% and 50%, fine if not completely even probabilities on edges
+         // between 20% and 50%, fine if not completely even probabilities on edges
+        return 20 + round($this->decode_bot_secret(3) / 33);
     }
 
 
     private function get_production_algorithm() {
-        $schedule_rand = $this->decode_bot_secret(2) % 100;
+        $schedule_rand = $this->decode_bot_secret(2);
 
-        // TODO: these should not be equal chance as some are terrible by design
-        if($schedule_rand <= 19)
+        if($schedule_rand <= 39)
             return "SALES";
-        elseif($schedule_rand <= 39)
-            return "CURRENT_PRICE";
         elseif($schedule_rand <= 59)
             return "AVG_PRICE";
-        elseif($schedule_rand <= 79)
+        elseif($schedule_rand <= 74)
             return "HIGH_PRICE";
+        elseif($schedule_rand <= 89)
+            return "CURRENT_PRICE";
         else
             return "RANDOM";
     }
 
-
     private function get_purchase_schedule_number() {
-        $unique_schedule_count = ($this->strat == "C" || $this->strat == "F" ? 4 : 1);
-        // indies and techers only have a single purchase schedule because they either buy mil or tech
-        // rainbow doesn't use purchase schedules as of 20210409
-        return $this->decode_bot_secret(2) % $unique_schedule_count;
+        if($this->strat == "I" || $this->strat == "T" || $this->strat == "R")
+            return 0;
+        $schedule_rand = $this->decode_bot_secret(1);
+
+        // FUTURE: use names
+        if($schedule_rand <= 1)
+            return 0; // heavy military
+        elseif($schedule_rand <= 3)
+            return 1; // heavy tech
+        elseif($schedule_rand <= 6)
+            return 2;// favor military
+        else
+            return 3;// favor tech
     }
 
 

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -44,7 +44,9 @@ class cpref
         $this->mass_explore_stop_acreage_rep = ($this->is_clan_server ? 99999 : 10000);
         $this->mass_explore_stop_acreage_non_rep = ($this->is_clan_server ? 99999 : 8200);        
         $this->base_inherent_value_for_tech = 700;
-
+        // TODO: spal
+        // TODO: bpt (temporary?)
+        // TODO: landgoal
 
         // buying
         $this->purchase_schedule_number = $this->get_purchase_schedule_number();
@@ -58,8 +60,8 @@ class cpref
 
         // selling
         $this->production_algorithm = $this->get_production_algorithm();  
-        $this->market_search_look_back_hours = 2; // TODO: random, vary by server length
-        $this->chance_to_sell_based_on_avg_price = 50;
+        $this->market_search_look_back_hours = mt_rand(2, 8); //mt_rand(1, 8); // TODO: random, vary by server length
+        $this->chance_to_sell_based_on_avg_price = 50; 
         $this->chance_to_sell_based_on_current_price = 100 - $this->chance_to_sell_based_on_avg_price;
         $this->selling_price_max_distance = 15; // 15 means a country may sell up to 15% over or under market prices
         $this->selling_price_std_dev = 5;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -37,24 +37,39 @@ class cpref
         $this->gdi = $cpref_file->gdi;
         // end personality file issue
 
-        $this->market_search_look_back_hours = 2; // TODO: random, vary by server length
+
+        // general        
         $this->mass_explore_stop_acreage_rep = ($this->is_clan_server ? 99999 : 10000);
         $this->mass_explore_stop_acreage_non_rep = ($this->is_clan_server ? 99999 : 8200);        
         $this->base_inherent_value_for_tech = 700;
-        // TODO: max bushel buy price
-        $this->tech_max_purchase_price = 9999;     
-        $this->production_algorithm = $this->get_production_algorithm();  
+
+
+        // buying
         $this->purchase_schedule_number = $this->get_purchase_schedule_number();
         $this->target_cash_after_stockpiling = ($this->strat == "C" ? 1500000000 : 1800000000);
         $this->spend_extra_money_cooldown_turns = ($this->strat == "C" ? 5 : 7);
         $this->max_stockpiling_loss_percent = 60; // must be > 0
+        // TODO: max bushel buy price
+        $this->tech_max_purchase_price = 9999;     
 
+
+        // selling
+        $this->production_algorithm = $this->get_production_algorithm();  
+        $this->market_search_look_back_hours = 2; // TODO: random, vary by server length
+        $this->chance_to_sell_based_on_avg_price = 50;
+        $this->chance_to_sell_based_on_current_price = 100 - $this->chance_to_sell_based_on_avg_price;
+        $this->selling_price_max_distance = 15; // 15 means a country may sell up to 15% over or under market prices
+        $this->selling_price_std_dev = 5;
+
+
+        // destocking
         $this->earliest_destocking_start_time = $this->get_earliest_destocking_start_time();
+
 
     }//end __construct()
 
     private function get_production_algorithm() {
-        
+
         // TODO: implement
         return "RANDOM";
         return "SALES";

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -45,7 +45,7 @@ class cpref
 
 
         // buying
-        $this->purchase_schedule_number = $this->get_purchase_schedule_number();
+        $this->purchase_schedule_number = $this->get_purchase_schedule_number($cnum);
         $this->target_cash_after_stockpiling = ($this->strat == "C" ? 1500000000 : 1800000000);
         $this->spend_extra_money_cooldown_turns = ($this->strat == "C" ? 5 : 7);
         $this->max_stockpiling_loss_percent = 60; // must be > 0
@@ -85,8 +85,9 @@ class cpref
     }
 
 
-    private function get_purchase_schedule_number() {
+    private function get_purchase_schedule_number($cnum) {
         $unique_schedule_count = ($this->strat == "C" or $this->strat == "F" ? 4 : 1);
+        log_country_data($cnum, "strat is $this->strat");
         // indies and techers only have a single purchase schedule because they either buy mil or tech
         // rainbow doesn't use purchase schedules as of 20210409
         return $this->decode_bot_secret(2) % $unique_schedule_count;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -188,7 +188,7 @@ class cpref
 
     public function calculate_next_play_in_seconds($nexttime, $exit_condition, $rules, $dynamic_country_settings) {
         // split for unit testing purposes
-        return $this->internal_calculate_next_play_in_seconds($this->cnum, $nexttime, $this->strat, $this->is_clan_server, $rules->max_time_to_market, $rules->max_possible_market_sell, $this->playrand, $this->reset_start_time, $this->reset_end_time, $this->server_turn_rate, $dynamic_country_settings->lastTurns, $rules->maxturns, $dynamic_country_settings->turnsStored, $rules->maxstore);
+        return $this->internal_calculate_next_play_in_seconds($this->cnum, $exit_condition, $nexttime, $this->strat, $this->is_clan_server, $rules->max_time_to_market, $rules->max_possible_market_sell, $this->playrand, $this->reset_start_time, $this->reset_end_time, $this->server_turn_rate, $dynamic_country_settings->lastTurns, $rules->maxturns, $dynamic_country_settings->turnsStored, $rules->maxstore);
     }
 
 

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -69,15 +69,20 @@ class cpref
     }//end __construct()
 
     private function get_production_algorithm() {
+        $schedule_rand = $this->decode_bot_secret(2) % 100;
 
-        // TODO: implement
-        return "RANDOM";
-        return "SALES";
-        return "HIGH_PRICE";
-        return "AVG_PRICE";       
-        return "CURRENT_PRICE";       
+        // TODO: these should not be equal chance as most are terrible by design
+        if($schedule_rand <= 19)
+            return "SALES";
+        elseif($schedule_rand <= 39)
+            return "CURRENT_PRICE";
+        elseif($schedule_rand <= 59)
+            return "AVG_PRICE";
+        elseif($schedule_rand <= 79)
+            return "HIGH_PRICE";
+        else
+            return "RANDOM";
     }
-
 
 
     private function get_purchase_schedule_number() {

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -81,7 +81,7 @@ class cpref
 
         // destocking uses shorter look backs
         $min_hours_to_look_back = floor(min(3, max(1, $number_of_days_in_set * 1 / 5))); // express would be 1, 30 day reset is 3, 60 day is 3 hours
-        $max_hours_to_look_back = floor(min(8, $number_of_days_in_set * 3 / 5)); // express would be 3, 30 day reset is 8, 60 day is 8 hours
+        $max_hours_to_look_back = floor(min(8, max(2, $number_of_days_in_set * 3 / 5))); // express would be 3, 30 day reset is 8, 60 day is 8 hours
         $this->market_search_look_back_hours_DESTOCK = mt_rand($min_hours_to_look_back, $max_hours_to_look_back); 
 
         $this->chance_to_sell_based_on_avg_price = 50; 

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -86,8 +86,8 @@ class cpref
 
 
     private function get_purchase_schedule_number($cnum) {
-        $unique_schedule_count = ($this->strat == "C" or $this->strat == "F" ? 4 : 1);
-        log_country_data($cnum, "strat is $this->strat");
+        $unique_schedule_count = ($this->strat == "C" || $this->strat == "F" ? 4 : 1);
+        //log_country_message($cnum, "strat is $this->strat");
         // indies and techers only have a single purchase schedule because they either buy mil or tech
         // rainbow doesn't use purchase schedules as of 20210409
         return $this->decode_bot_secret(2) % $unique_schedule_count;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -397,15 +397,16 @@ class cpref
         if (time() + $seconds_until_next_play > $server_reset_start + 0.995 * $seconds_in_reset) {
             $target_play_time_range_start = $server_reset_start + 0.985 * $seconds_in_reset;
             $target_play_time_range_end = $server_reset_start + 0.995 * $seconds_in_reset;
+            $seconds_between_targets = $target_play_time_range_end - $target_play_time_range_start;
     
             log_country_message($cnum, "Previous calculated value of $seconds_until_next_play is too close to the end of the set");
      
             // random range between 98.5% and 99.5% of reset
-            $seconds_until_next_play = $server_reset_start + 0.01 * mt_rand(0, 100) * (0.995 - 0.985) * $seconds_in_reset - time();
+            $seconds_until_next_play = ($target_play_time_range_start + 0.01 * mt_rand(0, 100) * $seconds_between_targets) - time();
     
             if ($seconds_until_next_play <= 0) {
                 $seconds_until_next_play = 1800; // not sure how we could get here, but set it to half an hour
-                // FUTURE: log error
+                log_error_message(124, $cnum, '$seconds_until_next_play was calculated as below 0');
             }
             log_country_message($cnum, "Next play changed to $seconds_until_next_play to allow for destocking");
         }

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -42,7 +42,8 @@ class cpref
         $this->mass_explore_stop_acreage_non_rep = ($this->is_clan_server ? 99999 : 8200);        
         $this->base_inherent_value_for_tech = 700;
         // TODO: max bushel buy price
-        $this->tech_max_purchase_price = 9999;        
+        $this->tech_max_purchase_price = 9999;     
+        $this->production_algorithm = $this->get_production_algorithm();  
         $this->purchase_schedule_number = $this->get_purchase_schedule_number();
         $this->target_cash_after_stockpiling = ($this->strat == "C" ? 1500000000 : 1800000000);
         $this->spend_extra_money_cooldown_turns = ($this->strat == "C" ? 5 : 7);
@@ -51,6 +52,17 @@ class cpref
         $this->earliest_destocking_start_time = $this->get_earliest_destocking_start_time();
 
     }//end __construct()
+
+    private function get_production_algorithm() {
+        
+        // TODO: implement
+        return "RANDOM";
+        return "SALES";
+        return "HIGH_PRICE";
+        return "AVG_PRICE";       
+        return "CURRENT_PRICE";       
+    }
+
 
 
     private function get_purchase_schedule_number() {

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -13,6 +13,8 @@
 
 namespace EENPC;
 
+// TODO: stop using and or
+
 class cpref
 {
 
@@ -45,13 +47,14 @@ class cpref
 
 
         // buying
-        $this->purchase_schedule_number = $this->get_purchase_schedule_number($cnum);
+        $this->purchase_schedule_number = $this->get_purchase_schedule_number();
         $this->target_cash_after_stockpiling = ($this->strat == "C" ? 1500000000 : 1800000000);
         $this->spend_extra_money_cooldown_turns = ($this->strat == "C" ? 5 : 7);
         $this->max_stockpiling_loss_percent = 60; // must be > 0
         // TODO: max bushel buy price
         $this->tech_max_purchase_price = 9999;     
-
+        // techers probably need to buy everything off PM, but other strats can likely skip turrets
+        $this->final_dpnw_for_stocking_calcs = ($this->strat == "T" ? (2025 / 6.5) : (3*144+588+2.5*192)/(1.5+2+0.6*2.5));
 
         // selling
         $this->production_algorithm = $this->get_production_algorithm();  
@@ -85,9 +88,8 @@ class cpref
     }
 
 
-    private function get_purchase_schedule_number($cnum) {
+    private function get_purchase_schedule_number() {
         $unique_schedule_count = ($this->strat == "C" || $this->strat == "F" ? 4 : 1);
-        //log_country_message($cnum, "strat is $this->strat");
         // indies and techers only have a single purchase schedule because they either buy mil or tech
         // rainbow doesn't use purchase schedules as of 20210409
         return $this->decode_bot_secret(2) % $unique_schedule_count;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -44,6 +44,9 @@ class cpref
         $this->mass_explore_stop_acreage_rep = ($this->is_clan_server ? 99999 : 10000);
         $this->mass_explore_stop_acreage_non_rep = ($this->is_clan_server ? 99999 : 8200);        
         $this->base_inherent_value_for_tech = 700;
+        // if tpt is high enough, spend this percentage of turns teching before considering exploring
+        $this->min_perc_teching_turns = $this->get_min_perc_teching_turns();
+
         // TODO: spal
         // TODO: bpt (temporary?)
         // TODO: landgoal
@@ -72,6 +75,14 @@ class cpref
 
 
     }//end __construct()
+
+
+
+
+    private function get_min_perc_teching_turns() {
+        return 10 + round($this->decode_bot_secret(3) / 25); // between 10% and 50%, fine if not completely even probabilities on edges
+    }
+
 
     private function get_production_algorithm() {
         $schedule_rand = $this->decode_bot_secret(2) % 100;

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -207,7 +207,7 @@ class cpref
                 log_country_message($cnum, "Country played a low number of turns, so set next login to 30 min + 50% of max time to market");
                 return ceil(1800 + 0.5 * $max_time_to_market);
             }
-            else
+            elseif($exit_condition <> 'NORMAL')
                 log_error_message(999, $cnum, "internal_calculate_next_play_in_seconds(): invalid value for exit condition: $exit_condition");
         }
     

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -71,7 +71,7 @@ class cpref
     private function get_production_algorithm() {
         $schedule_rand = $this->decode_bot_secret(2) % 100;
 
-        // TODO: these should not be equal chance as most are terrible by design
+        // TODO: these should not be equal chance as some are terrible by design
         if($schedule_rand <= 19)
             return "SALES";
         elseif($schedule_rand <= 39)

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -35,7 +35,7 @@ class cpref
         $this->bot_secret_number = $cpref_file->bot_secret;
         $this->playrand = $cpref_file->playrand;
         $this->price_tolerance = $cpref_file->price_tolerance;
-        $this->acquire_ingame_allies = $cpref_file->allyup;
+        $this->acquire_ingame_allies = ($this->is_clan_server ? $cpref_file->allyup : false); // no allies on non-clan servers for now
         $this->gdi = $cpref_file->gdi;
         // end personality file issue
 
@@ -47,16 +47,16 @@ class cpref
         // if tpt is high enough, spend this percentage of turns teching before considering exploring
         $this->min_perc_teching_turns = $this->get_min_perc_teching_turns();
 
-        // TODO: spal
-        // TODO: bpt (temporary?)
-        // TODO: landgoal
+        // FUTURE: spal
+        // FUTURE: bpt (temporary?)
+        // FUTURE: landgoal
 
         // buying
         $this->purchase_schedule_number = $this->get_purchase_schedule_number();
-        $this->target_cash_after_stockpiling = ($this->strat == "C" ? 1500000000 : 1800000000);
+        $this->target_cash_after_stockpiling = ($this->strat == "C" || $this->strat == "I" ? 1500000000 : 1800000000);
         $this->spend_extra_money_cooldown_turns = ($this->strat == "C" ? 5 : 7);
         $this->max_stockpiling_loss_percent = 60; // must be > 0
-        // TODO: max bushel buy price
+        $this->max_bushel_buy_price_with_low_stored_turns = 99;
         $this->tech_max_purchase_price = 9999;     
         // techers probably need to buy everything off PM, but other strats can likely skip turrets
         $this->final_dpnw_for_stocking_calcs = ($this->strat == "T" ? (2025 / 6.5) : (3*144+588+2.5*192)/(1.5+2+0.6*2.5));
@@ -69,7 +69,8 @@ class cpref
         $this->chance_to_sell_based_on_current_price = 100 - $this->chance_to_sell_based_on_avg_price;
         $this->selling_price_max_distance = 15; // 15 means a country may sell up to 15% over or under market prices
         $this->selling_price_std_dev = 5;
-
+        $this->farmer_max_early_sell_price = 49;
+        $this->farmer_max_late_sell_price = 99;
 
         // destocking
         $this->earliest_destocking_start_time = $this->get_earliest_destocking_start_time();

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -26,6 +26,7 @@ spl_autoload_register(
 require_once 'Terminal.class.php';
 require_once 'communication.php';
 
+// TODO: test on server
 // don't allow the process to be kicked off concurrently by accident
 // this seemingly cannot be in a function because a return releases the lock?
 $fp0 = fopen('zz_lock.txt', 'c');

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -356,8 +356,10 @@ while (1) {
                 else { // not destocking
                     log_country_message($cnum, 'Not doing destocking actions');    
 
+                    Allies::decline_all_allies_if_needed($cpref);
+
                     if ($cpref_file->allyup) {
-                        Allies::fill('def');
+                        Allies::fill($cpref, 'def');
                     }
 
                     Events::new();
@@ -746,6 +748,9 @@ function update_c(&$c, $result)
     $c->money += $netmoney;
     $c->food  += $netfood;
 
+    // update if we left protection
+    if($c->turns_played >= 100 and $c->protection == 1)
+        $c->protection = 0;
 
     // check that there aren't other reasons to update the advisor
     // current example is recall goods and recall tech don't tell us what was sent back
@@ -803,7 +808,10 @@ function update_c(&$c, $result)
     $APICalls = 0;
 
     // returning the number of turns played is useful for logging purposes
-    return [$turn_action => $c->turns_played - $turns_played_before_turns];
+    $action_and_turns_used = [];
+    if($turn_action)
+        $action_and_turns_used = [$turn_action => $c->turns_played - $turns_played_before_turns];
+    return $action_and_turns_used;
 }//end update_c()
 
 

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -114,7 +114,6 @@ $played     = true;
 $checked_for_non_ai = false;
 $set_strategies = true;
 
-
 //$market            = new PublicMarket();
 $server_avg_networth = $server_avg_land = 0;
 
@@ -336,8 +335,6 @@ while (1) {
             
             $debug_force_destocking = false; // DEBUG: change to true to force destocking code to run
             $is_destocking = ($debug_force_destocking or time() >= $earliest_destock_time? true : false);
-
-           // $is_destocking = false; // DEBUG
 
             // log snapshot of country status
             $prev_c_values = [];

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -342,7 +342,7 @@ while (1) {
             // log snapshot of country status
             $prev_c_values = [];
             $init_c = get_advisor();
-            log_snapshot_message($init_c, "BEGIN", $cpref_file->strat, $is_destocking, $prev_c_values);
+            log_snapshot_message($init_c, $rules, "BEGIN", $cpref_file->strat, $is_destocking, $prev_c_values);
             unset($init_c);
 
             try {
@@ -401,20 +401,12 @@ while (1) {
                     if ($c->turns_played < 100 && $cpref_file->retal) {
                         $cpref_file->retal = []; //clear the damned retal thing
                     }
-
-                    if($exit_condition == 'WAIT_FOR_PUBLIC_MARKET_FOOD') {
-                        log_country_message($cnum, "Country is holding turns while waiting for cheaper public market food to appear");
-                        $nexttime = 4 * $server->turn_rate;
-                    }
-
-                    // $maxin           = Bots::furthest_play($cpref_file); // now handled in calculate_next_play_in_seconds
-                    // $nexttime        = round(min($maxin, $nexttime));
                 }
 
                 log_country_message($cnum, "End playing standard ".Bots::txtStrat($cnum)." turns with exit condition $exit_condition");
 
                 // $seconds_to_next_play = calculate_next_play_in_seconds($cnum, $nexttime, $cpref_file->strat, $rules->is_clan_server, $rules->max_time_to_market, $rules->max_possible_market_sell, $cpref_file->playrand, $server->reset_start, $server->reset_end, $server->turn_rate, $cpref_file->lastTurns, $rules->maxturns, $cpref_file->turnsStored, $rules->maxstore);
-                $seconds_to_next_play = $cpref->calculate_next_play_in_seconds($nexttime, $rules, $cpref_file);
+                $seconds_to_next_play = $cpref->calculate_next_play_in_seconds($nexttime, $exit_condition, $rules, $cpref_file);
                 
                 $cpref_file->lastplay = time();
                 $cpref_file->nextplay = $cpref_file->lastplay + $seconds_to_next_play;
@@ -435,8 +427,8 @@ while (1) {
                 // log snapshots of country status
                 // FUTURE: skip snapshot parameter for speed for remote play?
                 $c = get_advisor(); // this call probably can't be avoided - market info, events, and tax/expenses could be wrong without it
-                log_snapshot_message($c, "DELTA", $cpref_file->strat, $is_destocking, $dummy, $prev_c_values);
-                log_snapshot_message($c, "END", $cpref_file->strat, $is_destocking, $dummy); // FUTURE: why does this take six seconds remotely?
+                log_snapshot_message($c, $rules, "DELTA", $cpref_file->strat, $is_destocking, $dummy, $prev_c_values);
+                log_snapshot_message($c, $rules, "END", $cpref_file->strat, $is_destocking, $dummy); // FUTURE: why does this take six seconds remotely?
                 
 
             } catch (Exception $e) {

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -26,14 +26,13 @@ spl_autoload_register(
 require_once 'Terminal.class.php';
 require_once 'communication.php';
 
-// TODO: test on server
 // don't allow the process to be kicked off concurrently by accident
 // this seemingly cannot be in a function because a return releases the lock?
 $fp0 = fopen('zz_lock.txt', 'c');
 if (flock($fp0, LOCK_EX | LOCK_NB)) // LOCK_NB makes it fail right away instead of waiting
     out("Lock acquired on zz_lock.txt, script will proceed"); 
 else
-    die("Lock could not be acquired on zz_lock.txt - is the process already running?");
+    die("Lock could not be acquired on zz_lock.txt - is the process already running?\n");
 
 
 out(Colors::getColoredString("STARTING UP BOT", "purple"));

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -375,7 +375,7 @@ while (1) {
                             $c = play_indy_strat($server, $cnum, $rules, $cpref, $exit_condition);
                             break;
                         default:
-                            $c = play_rainbow_strat($server, $cnum, $rules, $exit_condition);
+                            $c = play_rainbow_strat($server, $cnum, $rules, $cpref, $exit_condition);
                     }
 
                     if ($cpref_file->gdi && !$c->gdi) {

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -269,8 +269,6 @@ while (1) {
         }
 
         $cpref_file->retal = json_decode(json_encode($cpref_file->retal), true);
-// TODO: remove ALL references to $cpref_file if it should be a $cpref reference instead
-
 
         $mktinfo = null;
 

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -182,8 +182,6 @@ function sellextrafood_farmer(&$c, $server_base_pm_bushel_sell_price = 29, $bush
 
     $c = get_advisor();     //UPDATE EVERYTHING
 
-    $quantity = ['m_bu' => $c->food]; //sell it all! :)
-
     $pm_info = PrivateMarket::getRecent();
 
     $rmax    = 1.10; //percent
@@ -197,12 +195,11 @@ function sellextrafood_farmer(&$c, $server_base_pm_bushel_sell_price = 29, $bush
     $price   = max($bushel_min_sell_price, round($food_public_price * Math::purebell($rmin, $max, $rstddev, $rstep)));
 
     if ($price <= 1 + $pm_info->sell_price->m_bu / (2 - $c->tax())) {
-        return PrivateMarket::sell($c, ['m_bu' => $quantity]);
-        ///      PrivateMarket::sell($c,array('m_bu' => $c->food));   //Sell 'em
+        return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
     }
 
+    $quantity = ['m_bu' => $c->food]; //sell it all! :)
     $price_array   = ['m_bu' => $price];
-
     return PublicMarket::sell($c, $quantity, $price_array);    //Sell food!
 }//end sellextrafood_farmer()
 

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -148,7 +148,7 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         // don't see a strong reason to sell excess bushels at this step
     }
 
-    if($starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
+    if($exit_condition = 'NORMAL' && $starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
         $exit_condition = 'LOW_TURNS_PLAYED'; 
 
     $c->countryStats(FARMER);

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -89,7 +89,7 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         }
 
         $action_and_turns_used = update_c($c, $result);
-        update_intended_action_array($turn_action_counts, $action_and_turns_used);
+        update_turn_action_array($turn_action_counts, $action_and_turns_used);
 
         if (!$c->turns % 5) {                   //Grab new copy every 5 turns
             $c->updateMain(); //we probably don't need to do this *EVERY* turn
@@ -140,7 +140,7 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         // don't see a strong reason to sell excess bushels at this step
     }
 
-    $c->countryStats(FARMER); // , farmerGoals($c) FUTURE: implement?
+    $c->countryStats(FARMER);
     return $c;
 }//end play_farmer_strat()
 

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -194,7 +194,7 @@ function sellextrafood_farmer(&$c, $server_base_pm_bushel_sell_price = 29, $bush
     $food_public_price = $food_public_price ? $food_public_price : $server_base_pm_bushel_sell_price + 8;
     $price   = max($bushel_min_sell_price, round($food_public_price * Math::purebell($rmin, $max, $rstddev, $rstep)));
 
-    if ($price <= 1 + $pm_info->sell_price->m_bu / (2 - $c->tax())) {
+    if ($price <= $pm_info->sell_price->m_bu / (2 - $c->tax())) {
         return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
     }
 

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -62,8 +62,6 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     // log useful information about country state
     log_country_message($cnum, $c->turns.' turns left');
     //log_country_message($cnum, 'Explore Rate: '.$c->explore_rate.'; Min Rate: '.$c->explore_min);
-    //$pm_info = get_pm_info();   //get the PM info
-    //out_data($pm_info);       //output the PM info
     //$market_info = get_market_info();   //get the Public Market info
     //out_data($market_info);       //output the PM info
 
@@ -209,7 +207,6 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
 function sellextrafood_farmer(&$c, $rules, $bushel_min_sell_price, $bushel_max_sell_price, $cpref, $food_price_history)
 {
     //log_country_message($c->cnum, "Lots of food, let's sell some!");
-    //$pm_info = get_pm_info();
     //$market_info = get_market_info(); //get the Public Market info
     //global $market;
 

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -66,6 +66,8 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $owned_on_market_info = get_owned_on_market_info();     //find out what we have on the market
     //out_data($owned_on_market_info);  //output the Owned on Public Market info
 
+    attempt_to_recycle_bushels_but_avoid_buyout($c, $cpref, $food_price_history);
+
     if($c->money > 2000000000) { // try to stockpile to avoid corruption and to limit bot abuse
         // first spend extra money normally so we can buy needed military or income techs if they are worthwhile
         spend_extra_money($c, $buying_priorities, $cpref, $money_to_keep_after_stockpiling, false, $cost_for_military_point_guess, $dpnw_guess, $optimal_tech_buying_array, $buying_schedule);
@@ -191,10 +193,10 @@ function sellextrafood_farmer(&$c, $rules, $bushel_min_sell_price, $cpref, $food
     $pm_info = PrivateMarket::getRecent();
 
     // TODO: cpref
-    $rmax    = 1.10; //percent
+    $rmax    = 1.05; //percent
     $rmin    = 0.95; //percent
-    $rstep   = 0.01;
-    $rstddev = 0.10;
+    $rstep   = 0.001;
+    $rstddev = 0.025;
     $max     = $c->goodsStuck('m_bu') ? 0.99 : $rmax;  
     
     if (mt_rand(1, 100) <= $cpref->chance_to_sell_based_on_avg_price) {

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -70,7 +70,6 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
         spend_extra_money_on_stockpiling($c, $cpref, $money_to_keep_after_stockpiling, $stockpiling_weights, $stockpiling_adjustments);
     }
 
-    // TODO: a farmer probably won't be able to stock bushels? at some point bushels will get recalled, and then all will be sold because money happens to be below 2 B?
     if($c->money > 1000000000) // only called here to keep returned bushels on the market at high prices if we have a lot of cash
         stash_excess_bushels_on_public_if_needed($c, $rules);
 

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -14,6 +14,9 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
     log_country_message($cnum, "Indy: {$c->pt_indy}%; Bus: {$c->pt_bus}%; Res: {$c->pt_res}%; Mil: {$c->pt_mil}%; Weap: {$c->pt_weap}%");
 
+    // TODO: for techer, farmer, and indy: FAST NEXT LOGIN if we can't play more than a few turns
+
+
     log_country_message($cnum, "Getting military prices using market search looking back $cpref->market_search_look_back_hours hours", 'green');
     $military_unit_price_history = get_market_history_all_military_units($cnum, $cpref);
     set_indy_from_production_algorithm($c, $military_unit_price_history, $cpref, false); // changing to not check DPA - Slagpit 20210321
@@ -61,7 +64,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
         }
 
         $action_and_turns_used = update_c($c, $result);
-        update_intended_action_array($turn_action_counts, $action_and_turns_used);
+        update_turn_action_array($turn_action_counts, $action_and_turns_used);
 
         if (!$c->turns % 5) {                   //Grab new copy every 5 turns
             $c->updateMain(); //we probably don't need to do this *EVERY* turn
@@ -92,7 +95,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
     // total_cansell_military > 20000?
 
 
-    $c->countryStats(INDY); // indyGoals($c) // FUTURE: implement?
+    $c->countryStats(INDY);
 
     return $c;
 }//end play_indy_strat()

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -14,6 +14,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
     log_country_message($cnum, "Indy: {$c->pt_indy}%; Bus: {$c->pt_bus}%; Res: {$c->pt_res}%; Mil: {$c->pt_mil}%; Weap: {$c->pt_weap}%");
 
+    log_country_message($cnum, "Getting military prices using market search", 'green');
     $military_unit_price_history = get_market_history_all_military_units($cnum, $cpref);
     set_indy_from_production_algorithm($c, $military_unit_price_history, $cpref, false); // changing to not check DPA - Slagpit 20210321
 

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -14,7 +14,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
     log_country_message($cnum, "Indy: {$c->pt_indy}%; Bus: {$c->pt_bus}%; Res: {$c->pt_res}%; Mil: {$c->pt_mil}%; Weap: {$c->pt_weap}%");
 
-    log_country_message($cnum, "Getting military prices using market search", 'green');
+    log_country_message($cnum, "Getting military prices using market search looking back $cpref->market_search_look_back_hours hours", 'green');
     $military_unit_price_history = get_market_history_all_military_units($cnum, $cpref);
     set_indy_from_production_algorithm($c, $military_unit_price_history, $cpref, false); // changing to not check DPA - Slagpit 20210321
 

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -37,8 +37,6 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
     // log useful information about country state
     log_country_message($cnum, $c->turns.' turns left');
     //log_country_message($cnum, 'Explore Rate: '.$c->explore_rate.'; Min Rate: '.$c->explore_min);
-    //$pm_info = get_pm_info();   //get the PM info
-    //out_data($pm_info);       //output the PM info
     //$market_info = get_market_info();   //get the Public Market info
     //out_data($market_info);       //output the PM info
 

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -94,7 +94,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
     // FUTURE: always sell at end if possible - make sell_max_military get food/money to avoid OOF and OOM
     // total_cansell_military > 20000?
 
-    if($starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
+    if($exit_condition = 'NORMAL' && $starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
         $exit_condition = 'LOW_TURNS_PLAYED'; 
 
     $c->countryStats(INDY);

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -14,7 +14,8 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
     log_country_message($cnum, "Indy: {$c->pt_indy}%; Bus: {$c->pt_bus}%; Res: {$c->pt_res}%; Mil: {$c->pt_mil}%; Weap: {$c->pt_weap}%");
 
-    $c->setIndyFromMarket(false); // changing to not check DPA - Slagpit 20210321
+    $military_unit_price_history = get_market_history_all_military_units($cnum, $cpref);
+    set_indy_from_production_algorithm($c, $military_unit_price_history, $cpref, false); // changing to not check DPA - Slagpit 20210321
 
     if ($c->m_spy > 10000) {
         Allies::fill('spy');
@@ -28,9 +29,6 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $tech_inherent_value = get_inherent_value_for_tech($c, $rules, $cpref);
     $eligible_techs = ['t_bus', 't_res', 't_indy', 't_mil']; // don't buy t_weap for now - indies would over-prioritize it
     $optimal_tech_buying_array = get_optimal_tech_buying_array($c, $eligible_techs, $buying_priorities, $cpref->tech_max_purchase_price, $tech_inherent_value);
-    $military_unit_price_history = get_market_history_all_military_units($cpref);
-    // TODO: set indy production using $cpref->production_algorithm
-
 
     // TODO: some form of stockpiling?
 

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -4,7 +4,7 @@ namespace EENPC;
 
 $military_list = ['m_tr','m_j','m_tu','m_ta'];
 
-function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
+function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$turn_action_counts)
 {
     $exit_condition = 'NORMAL';
     //global $cnum;
@@ -52,16 +52,19 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
         spend_extra_money_no_military($c, $buying_priorities, $cpref, floor(0.8 * $c->fullBuildCost()) - $c->runCash(), $optimal_tech_buying_array);
     }
 
+    $turn_action_counts = [];
     $turns_played_for_last_spend_money_attempt = $c->turns_played;
     while ($c->turns > 0) {
         //$result = PublicMarket::buy($c,array('m_bu'=>100),array('m_bu'=>400));
-                
         $result = play_indy_turn($c, $rules->max_possible_market_sell, $is_allowed_to_mass_explore, $cpref);
         if ($result === false) {  //UNEXPECTED RETURN VALUE
             $c = get_advisor();     //UPDATE EVERYTHING
             continue;
         }
-        update_c($c, $result);
+
+        $action_and_turns_used = update_c($c, $result);
+        update_intended_action_array($turn_action_counts, $action_and_turns_used);
+
         if (!$c->turns % 5) {                   //Grab new copy every 5 turns
             $c->updateMain(); //we probably don't need to do this *EVERY* turn
         }

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -28,6 +28,9 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $tech_inherent_value = get_inherent_value_for_tech($c, $rules, $cpref);
     $eligible_techs = ['t_bus', 't_res', 't_indy', 't_mil']; // don't buy t_weap for now - indies would over-prioritize it
     $optimal_tech_buying_array = get_optimal_tech_buying_array($c, $eligible_techs, $buying_priorities, $cpref->tech_max_purchase_price, $tech_inherent_value);
+    $military_unit_price_history = get_market_history_all_military_units($cpref);
+    // TODO: set indy production using $cpref->production_algorithm
+
 
     // TODO: some form of stockpiling?
 
@@ -54,7 +57,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     while ($c->turns > 0) {
         //$result = PublicMarket::buy($c,array('m_bu'=>100),array('m_bu'=>400));
                 
-        $result = play_indy_turn($c, $rules->max_possible_market_sell, $is_allowed_to_mass_explore);
+        $result = play_indy_turn($c, $rules->max_possible_market_sell, $is_allowed_to_mass_explore, $cpref);
         if ($result === false) {  //UNEXPECTED RETURN VALUE
             $c = get_advisor();     //UPDATE EVERYTHING
             continue;
@@ -65,7 +68,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
         }
 
         // money and food management should be here because otherwise indies might not sell goods
-        $hold = money_management($c, $rules->max_possible_market_sell);
+        $hold = money_management($c, $rules->max_possible_market_sell, $cpref);
         if ($hold) {
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }
@@ -95,7 +98,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition)
 }//end play_indy_strat()
 
 
-function play_indy_turn(&$c, $server_max_possible_market_sell, $is_allowed_to_mass_explore)
+function play_indy_turn(&$c, $server_max_possible_market_sell, $is_allowed_to_mass_explore, $cpref)
 {
  //c as in country!
     $target_bpt = 65;
@@ -109,7 +112,7 @@ function play_indy_turn(&$c, $server_max_possible_market_sell, $is_allowed_to_ma
     } elseif ($c->protection == 0 && total_cansell_military($c, $server_max_possible_market_sell) > 7500 && sellmilitarytime($c)
         || $c->turns == 1 && total_cansell_military($c, $server_max_possible_market_sell) > 7500
     ) {
-        return sell_max_military($c, $server_max_possible_market_sell);
+        return sell_max_military($c, $server_max_possible_market_sell, $cpref);
     } elseif ($c->shouldBuildFullBPT($target_bpt)) {
         //build a full BPT if we can afford it
         return Build::indy($c);

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -11,6 +11,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
     //$main = get_main();     //get the basic stats
     //out_data($main);          //output the main data
     $c = get_advisor();     //c as in country! (get the advisor)
+    log_static_cpref_on_turn_0 ($c, $cpref);
     $starting_turns = $c->turns;
 
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
@@ -56,7 +57,7 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
     $turns_played_for_last_spend_money_attempt = $c->turns_played;
     while ($c->turns > 0) {
         //$result = PublicMarket::buy($c,array('m_bu'=>100),array('m_bu'=>400));
-        $result = play_indy_turn($c, $rules->max_possible_market_sell, $is_allowed_to_mass_explore, $cpref);
+        $result = play_indy_turn($c, $cpref, $rules->max_possible_market_sell, $is_allowed_to_mass_explore);
         if ($result === false) {  //UNEXPECTED RETURN VALUE
             $c = get_advisor();     //UPDATE EVERYTHING
             continue;
@@ -102,10 +103,9 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
 }//end play_indy_strat()
 
 
-function play_indy_turn(&$c, $server_max_possible_market_sell, $is_allowed_to_mass_explore, $cpref)
+function play_indy_turn(&$c, $cpref, $server_max_possible_market_sell, $is_allowed_to_mass_explore)
 {
- //c as in country!
-    $target_bpt = 65;
+    $target_bpt = $cpref->initial_bpt_target;
     global $turnsleep;
     usleep($turnsleep);
     //log_country_message($c->cnum, $main->turns . ' turns left');

--- a/rainbow_strat.php
+++ b/rainbow_strat.php
@@ -71,6 +71,7 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     //out_data($market_info);   //output the Public Market info
     //var_export($owned_on_market_info);
 
+    $turn_action_counts = []; // NOTE: this isn't properly set up for rainbows, but money_management() needs it
     while ($c->turns > 0) {
         //$result = PublicMarket::buy($c,array('m_bu'=>100),array('m_bu'=>400));
                 
@@ -85,7 +86,7 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
         }
 
         // management is here to make sure that goods can be sold
-        $hold = money_management($c, $rules->max_possible_market_sell, $cpref);
+        $hold = money_management($c, $rules->max_possible_market_sell, $cpref, $turn_action_counts);
         if ($hold) {
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }

--- a/rainbow_strat.php
+++ b/rainbow_strat.php
@@ -144,8 +144,7 @@ function play_rainbow_turn(&$c, $market_autobuy_tech_price, $server_max_possible
         return Build::cs(4); //build 4 CS
     } elseif ($c->tpt > $c->land * 0.10 && rand(0, 10) > 5) {
         //tech per turn is greater than land*0.17 -- just kindof a rough "don't tech below this" rule... lower for rainbow
-        return tech_techer($c, max(1, min(turns_of_money($c), turns_of_food($c), 13, $c->turns + 2) - 3));
-        //return tech_rainbow($c);
+        return tech_rainbow($c, max(1, min(turns_of_money($c), turns_of_food($c), 13, $c->turns + 2) - 3));
     } elseif ($c->built() > 50) {  //otherwise... explore if we can
         if ($c->explore_rate == $c->explore_min) {
             return explore($c, min(5, max(1, $c->turns - 1), max(1, min(turns_of_money($c), turns_of_food($c)) - 3)));
@@ -158,7 +157,7 @@ function play_rainbow_turn(&$c, $market_autobuy_tech_price, $server_max_possible
         || $c->turns == 1 && total_cansell_tech($c, $server_max_possible_market_sell) > 20
     ) {
         //never sell less than 20 turns worth of tech
-        return sell_max_tech($c, $market_autobuy_tech_price, $server_max_possible_market_sell);
+        return sell_max_tech($c, $cpref, $market_autobuy_tech_price, $server_max_possible_market_sell);
     } else { //otherwise...  cash
         return cash($c);
     }
@@ -223,37 +222,42 @@ function build_rainbow(&$c)
 }//end build_rainbow()
 
 
-function tech_rainbow(&$c, $turns=1)
+function tech_rainbow(&$c, $turns = 1)
 {
     //lets do random weighting... to some degree
-    $mil  = rand(0, 25);
-    $med  = rand(0, 5);
-    $bus  = rand(10, 100);
-    $res  = rand(10, 100);
-    $agri = rand(10, 100);
-    $war  = rand(0, 10);
-    $ms   = rand(0, 20);
-    $weap = rand(0, 20);
-    $indy = rand(5, 40);
-    $spy  = rand(0, 10);
-    $sdi  = rand(2, 15);
+    //$market_info = get_market_info();   //get the Public Market info
+    //global $market;
+
+    $techfloor = 600;
+
+    $mil  = max(pow(PublicMarket::price('mil') - $techfloor, 2), rand(0, 30000));
+    $med  = max(pow(PublicMarket::price('med') - $techfloor, 2), rand(0, 500));
+    $bus  = max(pow(PublicMarket::price('bus') - $techfloor, 2), rand(10, 40000));
+    $res  = max(pow(PublicMarket::price('res') - $techfloor, 2), rand(10, 40000));
+    $agri = max(pow(PublicMarket::price('agri') - $techfloor, 2), rand(10, 30000));
+    $war  = max(pow(PublicMarket::price('war') - $techfloor, 2), rand(0, 1000));
+    $ms   = max(pow(PublicMarket::price('ms') - $techfloor, 2), rand(0, 2000));
+    $weap = max(pow(PublicMarket::price('weap') - $techfloor, 2), rand(0, 2000));
+    $indy = max(pow(PublicMarket::price('indy') - $techfloor, 2), rand(5, 30000));
+    $spy  = max(pow(PublicMarket::price('spy') - $techfloor, 2), rand(0, 1000));
+    $sdi  = max(pow(PublicMarket::price('sdi') - $techfloor, 2), rand(2, 15000));
     $tot  = $mil + $med + $bus + $res + $agri + $war + $ms + $weap + $indy + $spy + $sdi;
 
-    $left  = $c->tpt;
-    $left -= $mil  = min($left, floor($c->tpt * ($mil / $tot)));
-    $left -= $med  = min($left, floor($c->tpt * ($med / $tot)));
-    $left -= $bus  = min($left, floor($c->tpt * ($bus / $tot)));
-    $left -= $res  = min($left, floor($c->tpt * ($res / $tot)));
-    $left -= $agri = min($left, floor($c->tpt * ($agri / $tot)));
-    $left -= $war  = min($left, floor($c->tpt * ($war / $tot)));
-    $left -= $ms   = min($left, floor($c->tpt * ($ms / $tot)));
-    $left -= $weap = min($left, floor($c->tpt * ($weap / $tot)));
-    $left -= $indy = min($left, floor($c->tpt * ($indy / $tot)));
-    $left -= $spy  = min($left, floor($c->tpt * ($spy / $tot)));
-    $left -= $sdi = max($left, min($left, floor($c->tpt * ($spy / $tot))));
+    $turns = max(1, min($turns, $c->turns));
+    $left  = $c->tpt * $turns;
+    $left -= $mil = min($left, floor($c->tpt * $turns * ($mil / $tot)));
+    $left -= $med = min($left, floor($c->tpt * $turns * ($med / $tot)));
+    $left -= $bus = min($left, floor($c->tpt * $turns * ($bus / $tot)));
+    $left -= $res = min($left, floor($c->tpt * $turns * ($res / $tot)));
+    $left -= $agri = min($left, floor($c->tpt * $turns * ($agri / $tot)));
+    $left -= $war = min($left, floor($c->tpt * $turns * ($war / $tot)));
+    $left -= $ms = min($left, floor($c->tpt * $turns * ($ms / $tot)));
+    $left -= $weap = min($left, floor($c->tpt * $turns * ($weap / $tot)));
+    $left -= $indy = min($left, floor($c->tpt * $turns * ($indy / $tot)));
+    $left -= $spy = min($left, floor($c->tpt * $turns * ($spy / $tot)));
+    $left -= $sdi = max($left, min($left, floor($c->tpt * $turns * ($sdi / $tot))));
     if ($left != 0) {
-        log_country_message($c->cnum, "What the hell?");
-        return;
+        die("What the hell?");
     }
 
     return tech(
@@ -269,8 +273,7 @@ function tech_rainbow(&$c, $turns=1)
             'indy' => $indy,
             'spy' => $spy,
             'sdi' => $sdi
-        ],
-        $turns
+        ]
     );
 }//end tech_rainbow()
 

--- a/rainbow_strat.php
+++ b/rainbow_strat.php
@@ -61,8 +61,6 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     //}
 
     //get the PM info
-    //$pm_info = get_pm_info();
-    //out_data($pm_info);       //output the PM info
     //$market_info = get_market_info();   //get the Public Market info
     //out_data($market_info);       //output the PM info
 
@@ -259,7 +257,7 @@ function tech_rainbow(&$c, $turns = 1)
     $left -= $spy = min($left, floor($c->tpt * $turns * ($spy / $tot)));
     $left -= $sdi = max($left, min($left, floor($c->tpt * $turns * ($sdi / $tot))));
     if ($left != 0) {
-        die("What the hell?");
+        die("What the hell? rainbow");
     }
 
     return tech(

--- a/rainbow_strat.php
+++ b/rainbow_strat.php
@@ -43,21 +43,22 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     }
 
     if ($c->m_spy > 10000) {
-        Allies::fill('spy');
+        Allies::fill($cpref, 'spy');
     }
 
     if ($c->b_lab > 2000) {
-        Allies::fill('res');
+        Allies::fill($cpref, 'res');
     }
 
     if ($c->m_j > 1000000) {
-        Allies::fill('off');
+        Allies::fill($cpref, 'off');
     }
 
-    //because why n
-    if ($c->govt == 'M') {
-        Allies::fill('trade');
-    }
+    //because why not?
+    // it's confusing for players, especially new ones - Slagpit
+    //if ($c->govt == 'M') {
+    //    Allies::fill($cpref, 'trade');
+    //}
 
     //get the PM info
     //$pm_info = get_pm_info();
@@ -89,7 +90,7 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }
 
-        $hold = food_management($c);
+        $hold = food_management($c, $cpref);
         if ($hold) {
             $exit_condition = 'WAIT_FOR_PUBLIC_MARKET_FOOD'; 
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!

--- a/rainbow_strat.php
+++ b/rainbow_strat.php
@@ -2,7 +2,7 @@
 
 namespace EENPC;
 
-function play_rainbow_strat($server, $cnum, $rules, &$exit_condition)
+function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
 {
     $exit_condition = 'NORMAL';
     //global $cnum;
@@ -84,7 +84,7 @@ function play_rainbow_strat($server, $cnum, $rules, &$exit_condition)
         }
 
         // management is here to make sure that goods can be sold
-        $hold = money_management($c, $rules->max_possible_market_sell);
+        $hold = money_management($c, $rules->max_possible_market_sell, $cpref);
         if ($hold) {
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -165,8 +165,8 @@ function play_techer_turn(&$c, $tech_price_min_sell_price, $server_max_possible_
             ($c->land < 1800 && $c->money > 2 * $c->explore_rate * (1500 + 3 * ($c->land + 2 * $c->explore_rate))) // at low acreage, enough money to build labs on 2 explore turns
             ||
             ($c->money + $c->turns * $c->income) > ( // turns is an over-estimate here, but probably ok
-                min($c->turns, ($c->built() * $c->land - $c->empty) / $c->explore_rate) * $c->explore_rate) * // explore turns
-                (1500 + 3 * ($c->land + min($c->turns, ($c->built() * $c->land - $c->empty) / $c->explore_rate) * $c->explore_rate) // building cost for new acres
+                min($c->turns, (0.01 * $c->built() * $c->land - $c->empty) / $c->explore_rate) * $c->explore_rate) * // explore turns
+                (1500 + 3 * ($c->land + min($c->turns, (0.01 * $c->built() * $c->land - $c->empty) / $c->explore_rate) * $c->explore_rate) // building cost for new acres
             )
         ) 
         // explore if land is less than 10k, we can explore, and we have less than 4 empty acres

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -75,7 +75,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         }
 
         $action_and_turns_used = update_c($c, $result);
-        update_intended_action_array($turn_action_counts, $action_and_turns_used);
+        update_turn_action_array($turn_action_counts, $action_and_turns_used);
 
         if (!$c->turns % 5) {                   //Grab new copy every 5 turns
             $c->updateMain(); //we probably don't need to do this *EVERY* turn
@@ -106,7 +106,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         // don't see a strong reason to sell excess bushels at this step
     }
 
-    $c->countryStats(TECHER); // , techerGoals($c) // FUTURE: implement?
+    $c->countryStats(TECHER);
 
     return $c;
 }//end play_techer_strat()

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -11,6 +11,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     //$main = get_main();     //get the basic stats
     //out_data($main);          //output the main data
     $c = get_advisor();     //c as in country! (get the advisor)
+    log_static_cpref_on_turn_0 ($c, $cpref);
     $starting_turns = $c->turns;
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
 
@@ -123,9 +124,9 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
 
 
 function play_techer_turn(&$c, $cpref, $rules, $tech_price_min_sell_price, $is_allowed_to_mass_explore, $tech_price_history, $tpt_split, &$teching_turns_remaining_before_explore)
-{
+{    
+    $target_bpt = $cpref->initial_bpt_target;
     $server_max_possible_market_sell = $rules->max_possible_market_sell;
-    $target_bpt = 65;
     global $turnsleep, $mktinfo; //, $server_avg_land;
     $mktinfo = null;
     usleep($turnsleep);
@@ -164,7 +165,7 @@ function play_techer_turn(&$c, $cpref, $rules, $tech_price_min_sell_price, $is_a
         $teching_turns_remaining_before_explore -= $turns_to_tech;
         return tech_techer($c, $turns_to_tech, $tpt_split);
     } elseif (
-        $c->built() > 50 && $c->land < $cpref->techer_land_goal &&
+        $cpref->techer_allowed_to_grow && $c->built() > 50 && $c->land < $cpref->techer_land_goal &&
         (
             ($c->empty < 4 && $c->land < 1800) // always allow for early exploring (cs)
             ||
@@ -278,7 +279,7 @@ function sell_max_tech(&$c, $cpref, $tech_price_min_sell_price, $server_max_poss
         } else {
             $max = $c->goodsStuck($key) ? 0.98 : $rmax; //undercut if we have goods stuck
             // there's a random chance to sell based on market average prices instead of current prices
-            $use_avg_price = ($allow_average_prices and mt_rand(1, 100) <= $cpref->chance_to_sell_based_on_avg_price) ? true : false;
+            $use_avg_price = ($allow_average_prices && $cpref->get_sell_price_method(false) == 'AVG') ? true : false;
 
             if($dump_at_min_sell_price)
                 $price[$key] = $tech_price_min_sell_price;

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -127,6 +127,7 @@ function play_techer_turn(&$c, $tech_price_min_sell_price, $server_max_possible_
     $mil_tech_to_keep = min($c->t_mil, ($c->govt == 'D' ? 42 : 0) * $c->land); // for demo recycling
 
     // TODO: why does building 4 cs become so slow? can_sell_tech? after protection? selltechtime ?
+    // TODO: 10k is probably too high for express given their play style
     // FUTURE: maybe split logic for < target BPT, < 1800 A, and otherwise
 
     if($c->land < 500 && $c->built() > 50) {

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -181,7 +181,7 @@ function selltechtime(&$c)
 function sell_max_tech(&$c, $cpref, $tech_price_min_sell_price, $server_max_possible_market_sell, $mil_tech_to_keep = 0,
     $dump_at_min_sell_price = false, $allow_average_prices = false, $tech_price_history = [])
 {
-    if($allow_average_prices and $tech_price_history === []) {
+    if($allow_average_prices && empty($tech_price_history)) {
         log_error_message(999, $c->cnum, 'sell_max_tech() allowed average price selling but $tech_price_history was empty');
         $allow_average_prices = false;
     }

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -13,7 +13,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $c = get_advisor();     //c as in country! (get the advisor)
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
 
-    log_country_message($cnum, "Getting tech prices using market search", 'green');
+    log_country_message($cnum, "Getting tech prices using market search looking back $cpref->market_search_look_back_hours hours", 'green');
     $tech_price_history = get_market_history_all_tech($cnum, $cpref);
     $tpt_split = get_tpt_split_from_production_algorithm($c, $tech_price_history, $cpref);
 

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -142,7 +142,7 @@ function play_techer_turn(&$c, $tech_price_min_sell_price, $server_max_possible_
         //never sell less than 20 turns worth of tech
         //always sell if we can????
         return sell_max_tech($c, $cpref, $tech_price_min_sell_price, $server_max_possible_market_sell, $mil_tech_to_keep, false, true, $tech_price_history);
-    } elseif ($c->shouldBuildSpyIndies($target_bpt)) {
+    } elseif ($c->land >= 1500 && $c->shouldBuildSpyIndies($target_bpt)) { // techer can have early income problems so don't build indies right away
         //build a full BPT of indies if we have less than that, and we're out of protection
         return Build::indy($c);
     } elseif ($c->shouldBuildFullBPT($target_bpt)) {

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -133,7 +133,7 @@ function play_techer_turn(&$c, $tech_price_min_sell_price, $server_max_possible_
         //tech per turn is greater than land*0.17 -- just kindof a rough "don't tech below this" rule...
         //so, 10 if they can... cap at turns - 1
         return tech_techer($c, max(1, min(turns_of_money($c), turns_of_food($c), 13, $c->turns + 2) - 3), $tpt_split);
-    } elseif ($c->built() > 50 and $c->land < 10000 and ($c->land < 5000 or $c->built() >= 97)
+    } elseif ($c->built() > 50 && $c->land < 10000 && ($c->land < 5000 || $c->built() >= 97)
         //&& ($c->land < 5000 || rand(0, 100) > 95 && $c->land < $server_avg_land)
         // 5k land is too low, techer bots are always below bot avg land, and the 5% chance is here is after the 3% chance from the prev line
     ) {

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -20,11 +20,11 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     $c->setIndy('pro_spy');
 
     if ($c->m_spy > 10000) {
-        Allies::fill('spy');
+        Allies::fill($cpref, 'spy');
     }
 
     if ($c->b_lab > 2000) {
-        Allies::fill('res');
+        Allies::fill($cpref, 'res');
     }
 
     techer_switch_government_if_needed($c);
@@ -57,7 +57,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         spend_extra_money_on_stockpiling($c, $cpref, $money_to_keep_after_stockpiling, $stockpiling_weights, $stockpiling_adjustments);
     }
 
-    stash_excess_bushels_on_public_if_needed($c, $rules); // TODO: money check (should be inside function)
+    stash_excess_bushels_on_public_if_needed($c, $rules);
 
     attempt_to_recycle_bushels_but_avoid_buyout($c, $cpref, $food_price_history);
 
@@ -87,7 +87,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }
 
-        $hold = food_management($c);
+        $hold = food_management($c, $cpref);
         if ($hold) {
             $exit_condition = 'WAIT_FOR_PUBLIC_MARKET_FOOD'; 
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
@@ -240,9 +240,6 @@ function sell_max_tech(&$c, $cpref, $tech_price_min_sell_price, $server_max_poss
     $rstep   = 0.01;
     $rstddev = 0.01 * $cpref->selling_price_std_dev;
     $price          = [];
-
-
-    // TODO: test selling by average...
 
     foreach ($quantity as $key => $q) {
         $t__key = "t_$key"; // :(

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -69,7 +69,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
         }
 
         // management is here to make sure that tech is sold
-        $hold = money_management($c, $rules->max_possible_market_sell);
+        $hold = money_management($c, $rules->max_possible_market_sell, $cpref);
         if ($hold) {
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -62,7 +62,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     attempt_to_recycle_bushels_but_avoid_buyout($c, $cpref, $food_price_history);
 
     $teching_turns_remaining_before_explore = floor(0.01 * $cpref->min_perc_teching_turns * $c->turns);
-    log_country_message($cnum, "Min teching turns before exploring is $teching_turns_remaining_before_explore based on preference $cpref->min_perc_teching_turns%");
+    log_country_message($cnum, "Min teching turns before exploring is $teching_turns_remaining_before_explore based on preference rate of $cpref->min_perc_teching_turns%");
 
     while ($c->turns > 0) {
         //$result = PublicMarket::buy($c,array('m_bu'=>100),array('m_bu'=>400));

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -129,7 +129,7 @@ function play_techer_turn(&$c, $tech_price_min_sell_price, $server_max_possible_
     } elseif ($c->shouldBuildFourCS($target_bpt)) {
         //build 4CS if we can afford it and are below our target BPT (80)
         return Build::cs(4); //build 4 CS
-    } elseif ($c->tpt > $c->land * 0.17 * 1.3 && $c->tpt > 100 && rand(0, 100) > 2) {
+    } elseif ($c->tpt > $c->land * 0.17 * 1.3 && $c->tpt > 100 && rand(1, 100) > 5) {
         //tech per turn is greater than land*0.17 -- just kindof a rough "don't tech below this" rule...
         //so, 10 if they can... cap at turns - 1
         return tech_techer($c, max(1, min(turns_of_money($c), turns_of_food($c), 13, $c->turns + 2) - 3), $tpt_split);

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -114,7 +114,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         // don't see a strong reason to sell excess bushels at this step
     }
 
-    if($starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
+    if($exit_condition = 'NORMAL' && $starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
         $exit_condition = 'LOW_TURNS_PLAYED'; 
 
     $c->countryStats(TECHER);

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -4,7 +4,7 @@ namespace EENPC;
 
 $techlist = ['t_mil','t_med','t_bus','t_res','t_agri','t_war','t_ms','t_weap','t_indy','t_spy','t_sdi'];
 
-function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
+function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$turn_action_counts)
 {
     $exit_condition = 'NORMAL';
     //global $cnum;
@@ -64,6 +64,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     $teching_turns_remaining_before_explore = floor(0.01 * $cpref->min_perc_teching_turns * $c->turns);
     log_country_message($cnum, "Min teching turns before exploring is $teching_turns_remaining_before_explore based on preference rate of $cpref->min_perc_teching_turns%");
 
+    $turn_action_counts = [];
     while ($c->turns > 0) {
         //$result = PublicMarket::buy($c,array('m_bu'=>100),array('m_bu'=>400));
                 
@@ -72,7 +73,10 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition)
             $c = get_advisor();     //UPDATE EVERYTHING
             continue;
         }
-        update_c($c, $result);
+
+        $action_and_turns_used = update_c($c, $result);
+        update_intended_action_array($turn_action_counts, $action_and_turns_used);
+
         if (!$c->turns % 5) {                   //Grab new copy every 5 turns
             $c->updateMain(); //we probably don't need to do this *EVERY* turn
         }
@@ -347,10 +351,10 @@ function techer_switch_government_if_needed($c) {
     if ($c->govt == 'M') {
         $rand = rand(0, 100);
         switch ($rand) {
-            case $rand < 40:
+            case $rand < 35:
                 Government::change($c, 'H');
                 break;
-            case $rand < 80:
+            case $rand < 85:
                 Government::change($c, 'D');
                 break;
             default:

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -136,7 +136,7 @@ function play_techer_turn(&$c, $tech_price_min_sell_price, $server_max_possible_
     } elseif ($c->tpt > $c->land * 0.17 * 1.3 && $c->tpt > 100 && $teching_turns_remaining_before_explore > 0) {
         //tech per turn is greater than land*0.17 -- just kindof a rough "don't tech below this" rule...
         //so, 10 if they can... cap at turns - 1
-        $turns_to_tech = max($teching_turns_remaining_before_explore, min(turns_of_money($c), turns_of_food($c), 13, $c->turns + 2) - 3);
+        $turns_to_tech = min($teching_turns_remaining_before_explore, min(turns_of_money($c), turns_of_food($c), 13, $c->turns + 2) - 3);
         $teching_turns_remaining_before_explore -= $turns_to_tech;
         return tech_techer($c, $turns_to_tech, $tpt_split);
     } elseif ($c->built() > 50 && $c->land < 10000 &&

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -46,8 +46,6 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     //log_country_message($cnum, 'Explore Rate: '.$c->explore_rate.'; Min Rate: '.$c->explore_min);
 
     //out_data($c);             //ouput the advisor data
-    //$pm_info = get_pm_info();   //get the PM info
-    //out_data($pm_info);       //output the PM info
     //$market_info = get_market_info();   //get the Public Market info
     //out_data($market_info);       //output the PM info
 


### PR DESCRIPTION
### REQUIRED
- remaining TODOs in code

### REQUIRED (TESTING)
- techers aim for 60 bpt
- mil reselling and buying more based on market conditions
- farmers shouldn't sell bushels at $100 or above under normal conditions ($50 early set)
- farmers are a bit less cs heavy at start, sell food on PM during protection
- on solo servers, bots reject allies and don't send them
- countries should stockpile
- add cashing too early country error
- https://github.com/jhaagsma/ee_npc/issues/20
- techers grow in a more reasonable fashion
- demos can bushel recycle during the set under certain conditions
- make recall goods function
- make recall tech function
- destock: techers can sell tech at reasonable prices and recall when it's time to dump tech at server min (only dump on Express)
- destock: let techers tech other things than mil tech once mil tech reaches goal
- destock: farmers can sell food at demo recycle max - 1 (recall stuck food at end)
- destock: all strats can recall bushels at very end	
- better tech production percentages
- better indy production percentages
- farmers should sell food on PM more often 
- farmers shouldn't cash instead of selling on private
- better farmer food sell prices - but it should usually be possible to sell above demo recycle limit (especially late in set)
- better tech sell prices
- better indy sell prices

### BUMPED

- can I get farmers selling food on public within 180 turns? would need to slow down cs I think, but that's probably a good thing
- https://github.com/jhaagsma/ee_npc/issues/21
- if high indy stored turns, recall goods (sell military on PM if needed), then dump goods at cheap prices on public
- get logout hours, then bump up max sell time from 8 hours if it would help? (Express only)
- stop indies from committing NW suicide if they get too many turns - can go into a cycle of continually selling 10% of military on PM	
- save exit condition to pref