### PR TITLE
Update farmer_strat.php

### DIFF
--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -174,7 +174,7 @@ function sellextrafood_farmer(&$c, $server_base_pm_bushel_sell_price = 29)
     $rstddev = 0.10;
     $max     = $c->goodsStuck('m_bu') ? 0.99 : $rmax;
     // don't dump food at +1 when the market is empty... can end up in a state where demo recyclers keep clearing it
-    $food_public_price = min($server_base_pm_bushel_sell_price + 7, PublicMarket::price('m_bu'));
+    $food_public_price = max($server_base_pm_bushel_sell_price + 7, PublicMarket::price('m_bu'));
     $price   = round(
         max(
             $pm_info->sell_price->m_bu + 3, // +3 instead of +1 to avoid losses from taxes


### PR DESCRIPTION
On the AI server, there's still cheap food getting sent to the market when bushel prices are high. This line:

$food_public_price = min($server_base_pm_bushel_sell_price + 7, PublicMarket::price('m_bu'));

should be

$food_public_price = max($server_base_pm_bushel_sell_price + 7, PublicMarket::price('m_bu'));