### PR TITLE
Rewrite part 5

### DIFF
--- a/Bots.class.php
+++ b/Bots.class.php
@@ -96,15 +96,15 @@ class Bots
         // a 20/20/20/20/20 split doesn't work well on the ai server
         // farmers end up not being able to sell food and troops can go to $40
         if($is_ai_server and !$is_debug_server) {
-            // per 25 countries: 2 farmer, 3 CI, 1 rainbow, 12 techer, 7 casher
+            // per 25 countries: 3 farmer, 3 CI, 2 rainbow, 10 techer, 7 casher
             // this doesn't handle a few country deletions well, but I don't think that it matters for ai server
             if (($country_position % 25) <= 6) {
                 return 'C';
-            } elseif  (($country_position % 25) <= 18) {
+            } elseif  (($country_position % 25) <= 16) {
                 return 'T';
-            } elseif  (($country_position % 25) <= 21) {
+            } elseif  (($country_position % 25) <= 19) {
                 return 'I';
-            } elseif  (($country_position % 25) <= 23) {
+            } elseif  (($country_position % 25) <= 22) {
                 return 'F';
             } else {
                 return 'R';

--- a/Bots.class.php
+++ b/Bots.class.php
@@ -93,6 +93,9 @@ class Bots
     public static function assign_strat_from_country_loop($country_position, $is_debug_server, $is_ai_server) {
         // FUTURE: make it easy to assign whatever mix of strategies we want with different mixes by server
 
+        return 'F'; // TODO DEBUG
+
+
         // a 20/20/20/20/20 split doesn't work well on the ai server
         // farmers end up not being able to sell food and troops can go to $40
         if($is_ai_server and !$is_debug_server) {

--- a/Bots.class.php
+++ b/Bots.class.php
@@ -93,9 +93,6 @@ class Bots
     public static function assign_strat_from_country_loop($country_position, $is_debug_server, $is_ai_server) {
         // FUTURE: make it easy to assign whatever mix of strategies we want with different mixes by server
 
-        return 'T'; // TODO DEBUG
-        // T is only one remaining
-
         // a 20/20/20/20/20 split doesn't work well on the ai server
         // farmers end up not being able to sell food and troops can go to $40
         if($is_ai_server and !$is_debug_server) {

--- a/Bots.class.php
+++ b/Bots.class.php
@@ -93,8 +93,8 @@ class Bots
     public static function assign_strat_from_country_loop($country_position, $is_debug_server, $is_ai_server) {
         // FUTURE: make it easy to assign whatever mix of strategies we want with different mixes by server
 
-        return 'F'; // TODO DEBUG
-
+        return 'T'; // TODO DEBUG
+        // T is only one remaining
 
         // a 20/20/20/20/20 split doesn't work well on the ai server
         // farmers end up not being able to sell food and troops can go to $40

--- a/Bots.class.php
+++ b/Bots.class.php
@@ -93,6 +93,8 @@ class Bots
     public static function assign_strat_from_country_loop($country_position, $is_debug_server, $is_ai_server) {
         // FUTURE: make it easy to assign whatever mix of strategies we want with different mixes by server
 
+        // return 'T'; // DEBUG
+
         // a 20/20/20/20/20 split doesn't work well on the ai server
         // farmers end up not being able to sell food and troops can go to $40
         if($is_ai_server and !$is_debug_server) {

--- a/Build.class.php
+++ b/Build.class.php
@@ -30,6 +30,23 @@ class Build
     }//end buildings()
 
 
+    public static function destroy_all_of_one_type(&$c, $building_type)
+    {
+        $buildings = [];
+        if($building_type == 'farm')
+            $buildings = ['farm' => $c->b_farm];
+        else // FUTURE: support all
+            log_error_message(999, $c->cnum, 'destroy_all_of_one_type(): invalid value for $building_type:'.$building_type);
+
+        ee('destroy', ['destroy' => $buildings]);
+
+        log_country_message($c->cnum, "Destroyed all buildings of type $building_type and updating advisor");
+        
+        // FUTURE: do incremental update
+        return false; //this will do $c->get_advisor();
+    }//end buildings()
+
+
     /**
      * Build CS
      *

--- a/Country.class.php
+++ b/Country.class.php
@@ -219,23 +219,31 @@ class Country
      */
     public function nlgTarget($powfactor = 1.00)
     {
-        //lets lower it from 80+turns_playwed/7, to compete
-        return floor(80 + pow($this->turns_played + $this->turns + $this->turns_stored, $powfactor) / 15);
+        if($this->turns_played + $this->turns + $this->turns_stored < 360)
+            return 0;
+        else {
+            //lets lower it from 80+turns_playwed/7, to compete
+            return floor(80 + pow($this->turns_played + $this->turns + $this->turns_stored, $powfactor) / 15);
+        }
     }//end nlgTarget()
 
 
     /**
      * A crude Defence Per Acre number
+     * $cpref - country preference object
      * @param float $mult      multiplication factor
      *
      *  @param float $powfactor power factor
      *
      * @return int DPATarget
      */
-    public function defPerAcreTarget($mult = 1.5, $powfactor = 1.0)
+    public function defPerAcreTarget($cpref, $mult = 1.5, $powfactor = 1.0)
     {
-        //out("Turns Played: {$this->turns_played}");
-        $dpat = floor(75 + pow($this->turns_played + $this->turns + $this->turns_stored, $powfactor) / 10) * $mult;
+        // fine if rainbows don't pass this in, screw them
+        if(isset($cpref) && $this->land < $cpref->min_land_to_buy_defense)
+            $dpat = 0;
+        else
+            $dpat = floor(75 + pow($this->turns_played + $this->turns + $this->turns_stored, $powfactor) / 10) * $mult;
         //log_country_message($this->cnum, "DPAT: $dpat"); // too much log spam - Slagpit
         return $dpat;
     }//end defPerAcreTarget()

--- a/Country.class.php
+++ b/Country.class.php
@@ -237,7 +237,7 @@ class Country
      *
      * @return int DPATarget
      */
-    public function defPerAcreTarget($cpref, $mult = 1.5, $powfactor = 1.0)
+    public function defPerAcreTarget($cpref = null, $mult = 1.5, $powfactor = 1.0)
     {
         // fine if rainbows don't pass this in, screw them
         if(isset($cpref) && $this->land < $cpref->min_land_to_buy_defense)
@@ -349,11 +349,11 @@ class Country
                 $price          = $price > 500 ? $price : 10000;
                 $score['t_mil'] = ($this->pt_mil - $goal[1]) / (100 - $goal[1]) * $goal[2] * (2500 / $price);
             } elseif ($goal[0] == 'nlg') {
-                $target       = $this->nlgt ?? $this->nlgTarget();
-                $score['nlg'] = ($target - $this->nlg()) / $target * $goal[2];
+                $target       = $this->nlgt ?? 1 + $this->nlgTarget(); // temp hack to avoid division by 0
+                $score['nlg'] = ($target - 1 + $this->nlg()) / $target * $goal[2];
             } elseif ($goal[0] == 'dpa') {
-                $target       = $this->dpat ?? $this->defPerAcreTarget();
-                $actual       = $this->defPerAcre();
+                $target       = $this->dpat ?? 1 + $this->defPerAcreTarget();
+                $actual       = 1 + $this->defPerAcre();
                 $score['dpa'] = ($target - $actual) / $target * $goal[2];
             }
 

--- a/Country.class.php
+++ b/Country.class.php
@@ -78,7 +78,7 @@ class Country
 
     public function get_foodcon_no_decay() {
         return floor($this->foodcon + 0.001 * $this->food); // FUTURE: set this in the object?
-    }
+    } 
 
 
     public function get_foodnet_no_decay() {

--- a/Country.class.php
+++ b/Country.class.php
@@ -76,6 +76,16 @@ class Country
     }//end updateOnMarket()
 
 
+    public function get_foodcon_no_decay() {
+        return floor($this->foodcon + 0.001 * $this->food); // FUTURE: set this in the object?
+    }
+
+
+    public function get_foodnet_no_decay() {
+        return floor($this->foodnet + 0.001 * $this->food); // FUTURE: set this in the object?
+    }
+
+
     public function onMarket($good = null)
     {
         if (!$this->market_info) {

--- a/Destocking.php
+++ b/Destocking.php
@@ -72,7 +72,7 @@ function execute_destocking_actions($cnum, $cpref, $server, $rules, &$next_play_
 		// $market_package_piece structure: [{"type":"t_mil","price":6277,"quantity":103068,"time":1617827768,"on_market":true,"seconds_until_on_market":-2362}]
 		if($market_package_piece->type == 'food') {
 			$bushels_on_market = true;
-			if ($market_package_piece->price > 2 + $estimated_public_market_bushel_sell_price) {
+			if ($market_package_piece->price > 2 + $public_bushel_avg_price) {
 				$expensive_bushels_on_market = true;				
 			}
 		}

--- a/Logging.php
+++ b/Logging.php
@@ -516,7 +516,7 @@ function generate_compact_country_status($c, $rules, $snapshot_type, $strat, $is
     $output_c_values['c_dstk'] = $is_destocking;
     $output_c_values['c_tax']  = $c->taxes;
     $output_c_values['c_exp']  = $c->expenses;
-    $output_c_values['c_netf'] = $c->foodnet;
+    $output_c_values['c_netf'] = $c->get_foodnet_no_decay();
     $output_c_values['c_neto'] = $c->oilpro;
     $output_c_values['c_tpt']  = $c->tpt;
     $output_c_values['c_neti'] = round($c->b_indy * 1.86 * 0.01 * $c->pt_indy * ($c->govt == 'C' ? 1.35 : 1.0)); // FUTURE: from game code

--- a/Logging.php
+++ b/Logging.php
@@ -125,7 +125,7 @@ function log_get_name_of_error_type($error_type) {
 
 
 function update_turn_action_array(&$turn_action_counts, $action_and_turns_used) {
-    if(!empty($action_and_turns_used)) {
+    if(!empty($action_and_turns_used) && is_array($action_and_turns_used)) {
         foreach($action_and_turns_used as $action => $turns_used) {
             if(isset($turn_action_counts[$action]))
                 $turn_action_counts[$action] += $turns_used;

--- a/PublicMarket.class.php
+++ b/PublicMarket.class.php
@@ -108,6 +108,15 @@ class PublicMarket
                 //out_data($result);
             }
 
+            /*
+            TODO
+            [2021-04-21 03:23:57] 
+ERROR 2001-PHP Warning; CNUM: #61; DETAILS: "/home/eenpc/ai_test/PublicMarket.class.php: 116","Division by zero",""
+
+[2021-04-21 03:23:57] --- BUY  Public:                 0  t_mil @ $NAN  (97.6%)    $494M         ($-0)
+*/
+
+
             $c->$type += $details->quantity;
             $c->money -= $details->cost;
             $tcost    += $details->cost;

--- a/PublicMarket.class.php
+++ b/PublicMarket.class.php
@@ -255,7 +255,7 @@ class PublicMarket
 
     // return amount spent
     // $tech_limit is an amount of tech that the country should not exceed
-    public static function buy_tech(&$c, $tech = 't_bus', $max_spend = null, $maxprice = 9999, $tech_limit = 999999999) // , &$last_price TODO
+    public static function buy_tech(&$c, $tech = 't_bus', $max_spend = null, $maxprice = 9999, $tech_limit = 999999999) // , &$last_price FUTURE
     {
         // $max_spend is now static, spent money is tracked via $total_spent
         $update = false;

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -609,10 +609,11 @@ function get_optimal_tech_from_ee ($tech_type, $min_cs, $min_tech_price, $max_te
     //$optimal_tech_array = $result->optimal_tech;
     // copying object values instead of a reference to an array is madness
     $optimal_tech_array = [];
-    foreach($result->optimal_tech as $turn_bucket => $turn_results)
-        foreach($turn_results as $turn_key => $t_p_q)
-            $optimal_tech_array[$turn_bucket][$turn_key] = (array)$t_p_q;
-
+    if(isset($result->optimal_tech)) {
+        foreach($result->optimal_tech as $turn_bucket => $turn_results)
+            foreach($turn_results as $turn_key => $t_p_q)
+                $optimal_tech_array[$turn_bucket][$turn_key] = (array)$t_p_q;
+    }
     //out_data($optimal_tech_array);
 
     return $optimal_tech_array; //$optimal_tech_array;

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -91,7 +91,7 @@ function spend_extra_money(&$c, $buying_priorities, $cpref, $money_to_reserve, $
                         unset($optimal_tech_buying_array[$priority_goal][$key]);
                     elseif($max_spend > 10 * $max_tech_price) {
                         // FUTURE: for bus/res, start by buying the one that the country has the least of?
-                        // TODO: cut down on API calls when tech market is empty or too highly priced? might as well for log spam reasons
+                        // FUTURE: cut down on API calls when tech market is empty or too highly priced? might as well for log spam reasons
                         // have a single prices skipped line with a comma delimited list
                         $total_spent_on_single_tech = PublicMarket::buy_tech($c, $tech_name, $max_spend, $max_tech_price, $tech_point_limit);
                         $max_spend -= $total_spent_on_single_tech; // have to update here for buy_tech() to not overbuy

--- a/Purchasing.php
+++ b/Purchasing.php
@@ -45,7 +45,7 @@ function spend_extra_money(&$c, $buying_priorities, $cpref, $money_to_reserve, $
     if($is_tech_goal_present and $skip_tech) // log this here to avoid spam
         log_country_message($c->cnum, "Optimal tech array is empty for goals which usually means tech is too expensive");    
 
-    $target_dpa = $c->defPerAcreTarget();
+    $target_dpa = $c->defPerAcreTarget($cpref);
     $target_dpnw = $c->nlgTarget(); 
 
     log_country_message($c->cnum, "Using schedule $buying_schedule, spend money with ".($delay_military_purchases ? "delayed mil purchases, " : "")."money: $c->money, max to spend: $max_spend, total reserved: $money_to_reserve", 'green');

--- a/Selling.php
+++ b/Selling.php
@@ -221,7 +221,7 @@ $high_price_score_array, $no_market_history_score_array, $current_price_score_ar
                 $number_of_units_with_no_data++;
         }
 
-        if($number_of_units_with_no_data == 4) { // we will rarely get false positives with this approach, but whatever
+        if($number_of_units_with_no_data == 4) { // we will rarely get false positives with this approach, but whatever // TODO: should be 11 for tech
             log_country_message($cnum, "Detected no market data so using default values");
             $production_score = $no_market_history_score_array;
         }
@@ -240,7 +240,7 @@ $high_price_score_array, $no_market_history_score_array, $current_price_score_ar
                 $number_of_units_with_no_data++;
         }
 
-        if($number_of_units_with_no_data == 4) { // we will rarely get false positives with this approach, but whatever
+        if($number_of_units_with_no_data == 4) { // we will rarely get false positives with this approach, but whatever // TODO: should be 11 for tech
             log_country_message($cnum, "Detected no market data so using default values");
             $production_score = $no_market_history_score_array;
         }

--- a/Selling.php
+++ b/Selling.php
@@ -318,7 +318,7 @@ function set_indy_from_production_algorithm(&$c, $military_unit_price_history, $
        
         // remove jets if we're checking DPA and it's too low
         if ($checkDPA) {
-            $target = $c->defPerAcreTarget();
+            $target = $c->defPerAcreTarget($cpref);
             if ($c->defPerAcre() < $target) {
                 //below def target, don't make jets
                 unset($production_score['m_j']);

--- a/Selling.php
+++ b/Selling.php
@@ -222,7 +222,7 @@ $high_price_score_array, $no_market_history_score_array, $current_price_score_ar
                 $number_of_units_with_no_data++;
         }
 
-        if($number_of_units_with_no_data == 4) { // we will rarely get false positives with this approach, but whatever // TODO: should be 11 for tech
+        if($number_of_units_with_no_data == count($production_factor_per_unit)) { // we will rarely get false positives with this approach, but whatever
             log_country_message($cnum, "Detected no market data so using default values");
             $production_score = $no_market_history_score_array;
         }
@@ -241,7 +241,7 @@ $high_price_score_array, $no_market_history_score_array, $current_price_score_ar
                 $number_of_units_with_no_data++;
         }
 
-        if($number_of_units_with_no_data == 4) { // we will rarely get false positives with this approach, but whatever // TODO: should be 11 for tech
+        if($number_of_units_with_no_data == count($production_factor_per_unit)) { // we will rarely get false positives with this approach, but whatever
             log_country_message($cnum, "Detected no market data so using default values");
             $production_score = $no_market_history_score_array;
         }

--- a/Selling.php
+++ b/Selling.php
@@ -37,7 +37,8 @@ function emergency_sell_mil_on_pm (&$c, $money_needed) {
     foreach($mil_sell_order as $mil_unit){
         $sell_price = $pm_info->sell_price->$mil_unit;
         $amount_to_sell = min($c->$mil_unit, ceil($money_needed / $sell_price));
-        PrivateMarket::sell_single_good($c, $mil_unit, $amount_to_sell);
+        if($amount_to_sell > 0)
+            PrivateMarket::sell_single_good($c, $mil_unit, $amount_to_sell);
         $money_needed -= $amount_to_sell * $sell_price;
         if($money_needed < 0)
             return true;
@@ -359,17 +360,17 @@ function get_tpt_split_from_production_algorithm(&$c, $tech_price_history, $cpre
         $production_score = [
             't_mil' => 0,
             't_med' => 0,
-            't_bus' => 50,
-            't_res' => 50,
-            't_agri' => 0,
+            't_bus' => 40,
+            't_res' => 40,
+            't_agri' => 15,
             't_war' => 0,
             't_ms' => 0,
             't_weap' => 0,
-            't_indy' => 0,
+            't_indy' => 5,
             't_spy' => 0,
             't_sdi' => 0
         ];
-        log_country_message($c->cnum, "Setting tech production to 50% bus/res because we haven't played 150 turns yet");
+        log_country_message($c->cnum, "Setting tech production to mostly bus/res because we haven't played 150 turns yet");
     }
     else { // not the first 150 turns        
         log_country_message($c->cnum, "Setting tech production using algorithm $cpref->production_algorithm", 'green');  

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -12,8 +12,8 @@ function stash_excess_bushels_on_public_if_needed(&$c, $rules, $max_sell_price =
             return false; // FUTURE: it is unfortunate to return a turn result or false
 
         // shouldn't be a big deal if we sell some bushels to fund running a turn, but just in case do the calc again:
-        $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * floor(min(0, ($c->foodnet + 0.001 * $c->food))));
-
+        $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * floor(min(0, $c->get_foodnet_no_decay())));
+        
         $quantity = ['m_bu' => $excess_bushels];
         if($max_sell_price) {
             $price   = ['m_bu' => $max_sell_price]; 
@@ -171,7 +171,7 @@ function get_farmer_min_sell_price($c, $cpref, $rules, $server, $min_cash_to_cal
 
 
 function is_country_expected_to_exceed_target_cash_during_turns($c, $target_cash){
-    return $c->money + $c->turns * max(0, $c->income) + $c->turns * 39 * max(0, $c->foodnet) >= $target_cash ? true : false;
+    return $c->money + 39 * $c->food + $c->turns * max(0, $c->income) + $c->turns * 39 * max(0, $c->foodnet) >= $target_cash ? true : false;
 }
 
 

--- a/Stockpiling.php
+++ b/Stockpiling.php
@@ -4,8 +4,7 @@ namespace EENPC;
 
 
 function stash_excess_bushels_on_public_if_needed(&$c, $rules, $max_sell_price = null) {
-    // 0.001 is for decay
-    $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * floor(min(0, ($c->foodnet + 0.001 * $c->food))));
+    $excess_bushels = $c->food - 50000 + ($c->foodnet > 0 ? 0 : ($c->turns + 20) * floor(min(0, $c->get_foodnet_no_decay())));
 
     if($excess_bushels > 3500000) {
         if(!food_and_money_for_turns($c, 1, 0, false, true)) // if false then we can't run a turn without hitting OOF

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -229,7 +229,7 @@ function casher_get_buying_priorities ($cnum, $buying_schedule) {
     return $buying_priorities;
 } // casher_get_buying_priorities()
 
-function casher_switch_government_if_needed($c) {
+function casher_switch_government_if_needed(&$c) {
     // FUTURE: should obviously call a function with priorities... (same with other strats)
     if ($c->govt == 'M') {
         $rand = rand(0, 100);

--- a/casher_strat.php
+++ b/casher_strat.php
@@ -113,7 +113,7 @@ function play_casher_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         // don't see a strong reason to sell excess bushels at this step
     }
 
-    $c->countryStats(CASHER);
+    //$c->countryStats(CASHER);
     return $c;
 }//end play_casher_strat()
 
@@ -139,7 +139,7 @@ function play_casher_turn(&$c, $cpref, $is_allowed_to_mass_explore)
         return Build::cs(4); //build 4 CS
     } elseif ($c->built() > 50) {
         //otherwise... explore if we can
-        $explore_turn_limit = $is_allowed_to_mass_explore ? 999 : 7; // match spend_money call
+        $explore_turn_limit = $is_allowed_to_mass_explore ? 999 : $cpref->spend_extra_money_cooldown_turns;
         return explore($c, max(1, min($explore_turn_limit, $c->turns, turns_of_food($c) - 4)));
     } else {
         //otherwise...  cash
@@ -221,20 +221,3 @@ function casher_switch_government_if_needed($c) {
         }
     }
 } // casher_switch_government_if_needed()
-
-
-/*
-function casherGoals(&$c)
-{
-    $bus_res_goal = ($c->govt == "H" ? 148 : 178);
-    return [
-        //what, goal, priority
-        ['t_bus',$bus_res_goal,800],
-        ['t_res',$bus_res_goal,800],
-        ['t_mil',94,100],
-        ['nlg',$c->nlgTarget(),200],
-        ['dpa',$c->defPerAcreTarget(1.0),400],
-        ['food', 1000000000, 1],
-    ];
-}//end casherGoals()
-*/

--- a/communication.php
+++ b/communication.php
@@ -217,6 +217,7 @@ function expected_result($input)
         'advisor' => 'ADVISOR',
         'main' => 'MAIN',
         'build' => 'BUILD',
+        'destroy' => 'DESTROY',
         'explore' => 'EXPLORE',
         'cash' => 'CASH',
         'pm_info' => 'PM_INFO',

--- a/country_functions.php
+++ b/country_functions.php
@@ -258,7 +258,8 @@ function food_management(&$c, $cpref)
 
         //log_country_message($c->cnum, "Market Price: " . $market_price);
         //losing food, less than turns_buy turns left, AND have the money to buy it
-        if ($c->food < $turns_of_food && $c->money > $turns_of_food * $market_price * $c->tax() && $c->money - $turns_of_food * $market_price * $c->tax() + $c->income * $turns_buy > 0) {
+        // always leave enough money to build 4 cs (helps in the beginning)
+        if ($c->food < $turns_of_food && $c->money > 4 * $c->build_cost + $turns_of_food * $market_price * $c->tax() && $c->money - $turns_of_food * $market_price * $c->tax() + $c->income * $turns_buy > 0) {
             $quantity = min($foodloss * $turns_buy, PublicMarket::available('m_bu'));
             // log_country_message($c->cnum, 
             //     "--- FOOD:  - Buy Public ".str_pad('('.$turns_buy, 17, ' ', STR_PAD_LEFT).

--- a/country_functions.php
+++ b/country_functions.php
@@ -213,7 +213,7 @@ function money_management(&$c, $server_max_possible_market_sell, $cpref, &$turn_
             log_country_message($c->cnum, "Selling max military, and holding turns.");
             $possible_turn_result = sell_max_military($c, $server_max_possible_market_sell, $cpref);
             if($possible_turn_result <> null)
-                update_turn_action_array($turn_action_counts, $possible_turn_result);
+                update_turn_action_array($turn_action_counts, ['sell' => 1]);
             return true;
         } elseif ($c->turns_stored > 30 && total_military($c) > 1000) {
             log_error_message(1002, $c->cnum, "We have stored turns or can't sell on public; sell 1/10 of military");
@@ -293,9 +293,13 @@ function food_management(&$c, $cpref)
         return false;
     }
 
+    if ($c->protection == 1 && $c->turns_stored < 30) {
+        log_country_message($c->cnum, "Hold turns to wait for food on market during protection because we have low stored turns");
+        return true;
+    }
+
     //WE HAVE MONEY, WAIT FOR FOOD ON MKT
     if ($c->protection == 0 && $c->turns_stored < 30 && $c->income > 64 * $foodloss) { // 64 is a reasonably high price for public bushel price
-        //Text for screen
         log_country_message($c->cnum, "We make enough to buy food if we want to; hold turns for now, and wait for food on MKT.");
         return true;
     }
@@ -308,7 +312,6 @@ function food_management(&$c, $cpref)
 
     if ($c->food < $turns_of_food && $c->money > $turns_buy * $foodloss * $pm_info->buy_price->m_bu) {
         //losing food, less than turns_buy turns left, AND have the money to buy it
-        //Text for screen
         // FUTURE: need to check quantity of food available on private market
         log_country_message($c->cnum, 
             "Less than $turns_buy turns worth of food! (".$c->foodnet."/turn) ".

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -187,7 +187,7 @@ class cpref
 
 
     private function get_min_land_to_buy_defense() {
-       return 1000 + round($this->decode_bot_secret(4) / 5000);
+       return 1000 + round($this->decode_bot_secret(4) / 5);
     }
 
 

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -203,8 +203,8 @@ class cpref
 
 
     private function get_techer_round_explore_cutoff_percentage() {
-        // between 45% and 65%, fine if not completely even probabilities on edges
-       return round(0.01 * (45 + $this->decode_bot_secret(5) / 5000), 2);
+        // between 40% and 60%, fine if not completely even probabilities on edges
+       return round(0.01 * (40 + $this->decode_bot_secret(5) / 5000), 2);
     } 
 
 

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -49,9 +49,11 @@ class cpref
 
 
         $number_of_seconds_in_set = $this->reset_end_time - $this->reset_start_time;
-        $this->techer_allowed_to_grow = (time() < 0.65 * $number_of_seconds_in_set + $this->reset_start_time) ? true : false; // weird to set only for techer
         $this->techer_land_goal = ($turns_in_set < 2200 ? 8000 : 10000); // FUTURE - this is very basic, also weird to only set for techer
-        
+         // weird to set only for techer
+        $this->techer_round_explore_cutoff_percentage = $this->get_techer_round_explore_cutoff_percentage();
+        $this->techer_allowed_to_explore = (time() < $this->techer_round_explore_cutoff_percentage * $number_of_seconds_in_set + $this->reset_start_time) ? true : false;
+
         $this->base_inherent_value_for_tech = 700;
         // if tpt is high enough, spend this percentage of turns teching before considering exploring
         $this->min_perc_teching_turns = $this->get_min_perc_teching_turns();
@@ -119,6 +121,9 @@ class cpref
             , "gdi"
             , "mass_explore_stop_acreage_rep"
             , "mass_explore_stop_acreage_non_rep"
+            , "techer_land_goal"
+            , "techer_round_explore_cutoff_percentage"
+            , "techer_allowed_to_explore"
             , "base_inherent_value_for_tech"
             , "purchase_schedule_number"
             , "min_land_to_buy_defense"
@@ -195,6 +200,13 @@ class cpref
          // between 20% and 50%, fine if not completely even probabilities on edges
         return 20 + round($this->decode_bot_secret(3) / 33);
     }
+
+
+    private function get_techer_round_explore_cutoff_percentage() {
+        // between 45% and 65%, fine if not completely even probabilities on edges
+       return round(0.01 * (45 + $this->decode_bot_secret(5) / 5000), 2);
+    } 
+
 
 
     private function get_production_algorithm() {

--- a/cpref.class.php
+++ b/cpref.class.php
@@ -62,6 +62,7 @@ class cpref
 
         // buying
         $this->purchase_schedule_number = $this->get_purchase_schedule_number();
+        $this->min_land_to_buy_defense = $this->get_min_land_to_buy_defense();        
         $this->target_cash_after_stockpiling = ($this->strat == "C" || $this->strat == "I" ? 1500000000 : 1800000000);
         $this->spend_extra_money_cooldown_turns = ($this->strat == "C" ? 5 : 7);
         $this->max_stockpiling_loss_percent = 60; // must be > 0
@@ -120,6 +121,7 @@ class cpref
             , "mass_explore_stop_acreage_non_rep"
             , "base_inherent_value_for_tech"
             , "purchase_schedule_number"
+            , "min_land_to_buy_defense"
             , "target_cash_after_stockpiling"
             , "spend_extra_money_cooldown_turns"
             , "max_bushel_buy_price_with_low_stored_turns"
@@ -180,6 +182,12 @@ class cpref
             else
                 return "CURRENT";     
         }
+    }
+
+
+
+    private function get_min_land_to_buy_defense() {
+       return 1000 + round($this->decode_bot_secret(4) / 5000);
     }
 
 

--- a/ee_npc.php
+++ b/ee_npc.php
@@ -276,7 +276,8 @@ while (1) {
             $cpref_file->retal = [];
         }
 
-        $cpref_file->retal = json_decode(json_encode($cpref_file->retal), true);
+
+        // $cpref_file->retal = json_decode(json_encode($cpref_file->retal), true); // errors out
 
         $mktinfo = null;
 
@@ -360,7 +361,7 @@ while (1) {
                     }
 
                     Events::new();
-                    Country::listRetalsDue();
+                    //Country::listRetalsDue(); // errors out
 
                     $nexttime = null;
                     $exit_condition = null;

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -70,6 +70,7 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
 
     attempt_to_recycle_bushels_but_avoid_buyout($c, $cpref, $food_price_history);
 
+    // FUTURE: what if we have a bunch of bushels that we plan to sell on PM?
     if($c->money > 2000000000) { // try to stockpile to avoid corruption and to limit bot abuse
         // first spend extra money normally so we can buy needed military or income techs if they are worthwhile
         spend_extra_money($c, $buying_priorities, $cpref, $money_to_keep_after_stockpiling, false, $cost_for_military_point_guess, $dpnw_guess, $optimal_tech_buying_array, $buying_schedule);
@@ -169,7 +170,7 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
         || (        
             $c->protection == 0 && $c->food > 7000
             && (
-                $c->foodnet > 0 && $c->foodnet > 3 * $c->foodcon && $c->food > 30 * $c->foodnet //Don't sell less than 30 turns of food unless you're on your last turn (and desperate?)
+                $c->foodnet > 0 && $c->foodnet > 3 * $c->get_foodcon_no_decay() && $c->food > 30 * $c->get_foodnet_no_decay() //Don't sell less than 30 turns of food unless you're on your last turn (and desperate?)
                 || $c->turns == 1
             )
         )

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -320,7 +320,7 @@ function sellextrafood_farmer(&$c, $rules, $bushel_min_sell_price, $bushel_max_s
 }//end sellextrafood_farmer()
 
 
-function farmer_switch_government_if_needed($c) {
+function farmer_switch_government_if_needed(&$c) {
     if ($c->govt == 'M') {
         $rand = rand(0, 100);
         switch ($rand) {

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -141,6 +141,9 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         ) {
         spend_extra_money($c, $buying_priorities, $cpref, floor(0.9*$c->fullBuildCost()), false, $cost_for_military_point_guess, $dpnw_guess, $optimal_tech_buying_array, $buying_schedule);
     }
+    else { // farmers can get caught in a pattern where they have enough cash for military, do a big mass explore, but now their building costs are too high so they can't buy military
+        spend_extra_money($c, $buying_priorities, $cpref, floor(0.10 * $c->money), false, $cost_for_military_point_guess, $dpnw_guess, $optimal_tech_buying_array, $buying_schedule);
+    }
 
     if($c->money > 2000000000) { // try to stockpile to avoid corruption and to limit bot abuse
         spend_extra_money_on_stockpiling($c, $cpref, $money_to_keep_after_stockpiling, $stockpiling_weights, $stockpiling_adjustments);
@@ -150,7 +153,7 @@ function play_farmer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     if($exit_condition = 'NORMAL' && $starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
         $exit_condition = 'LOW_TURNS_PLAYED'; 
 
-    $c->countryStats(FARMER);
+    //$c->countryStats(FARMER);
     return $c;
 }//end play_farmer_strat()
 
@@ -160,19 +163,20 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
     $target_bpt = $cpref->initial_bpt_target;
     global $turnsleep;
     usleep($turnsleep);
-    //log_country_message($c->cnum, $main->turns . ' turns left');
-    if ($c->shouldBuildSingleCS($target_bpt, 20)) {
+
+    if ($c->turns_played <= 99) {
+        return play_farmer_turn_first_99_turns($c, $cpref, $target_bpt);
+    } elseif ($c->land < 1800) {
+        return play_farmer_turn_first_1800_acres($c, $cpref, $rules, $target_bpt, $bushel_min_sell_price, $bushel_max_sell_price, $food_price_history);
+    } elseif ($c->shouldBuildSingleCS($target_bpt)) {
         //LOW BPT & CAN AFFORD TO BUILD
         //build one CS if we can afford it and are below our target BPT
         return Build::cs(); //build 1 CS
     } elseif (
-        ($c->protection == 1 && $c->food > 100 && $c->b_farm > 0) // sell on private in protection if food > 100 and we have at least one farm
-        || (        
             $c->protection == 0 && $c->food > 7000
             && (
-                $c->foodnet > 0 && $c->foodnet > 3 * $c->get_foodcon_no_decay() && $c->food > 30 * $c->get_foodnet_no_decay() //Don't sell less than 30 turns of food unless you're on your last turn (and desperate?)
+                $c->foodnet > 0 && $c->get_foodnet_no_decay() > 3 * $c->get_foodcon_no_decay() && $c->food > 30 * $c->get_foodnet_no_decay() //Don't sell less than 30 turns of food unless you're on your last turn (and desperate?)
                 || $c->turns == 1
-            )
         )
     ) { 
         // sell some food on PM if we have a lot of empty acres, still have turns, and can't afford to build at least 1k acres
@@ -194,7 +198,7 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
         //build 4CS if we can afford it and are below our target BPT (65)
         return Build::cs(4); //build 4 CS
     } elseif ($c->built() > 50) {  //otherwise... explore if we can
-        $explore_turn_limit = $is_allowed_to_mass_explore ? 999 : 7; // match spend_money call
+        $explore_turn_limit = $is_allowed_to_mass_explore ? 999 : $cpref->spend_extra_money_cooldown_turns;
         return explore($c, max(1,min($explore_turn_limit, $c->turns - 1, turns_of_money($c) - 4)));
     } elseif($c->food > 0) { // better to sell on PM than cash
         log_country_message($c->cnum, "Selling food on PM in an attempt to avoid cashing turns");
@@ -203,6 +207,60 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
         return cash($c); // FUTURE - hold turns instead if food is on market?
     }
 }//end play_farmer_turn()
+
+
+
+function play_farmer_turn_first_1800_acres (&$c, $cpref, $rules, $target_bpt, $bushel_min_sell_price, $bushel_max_sell_price, $food_price_history) {
+    if($c->food > 0 && $c->b_farm > 0 && $c->empty >= $c->bpt && $c->money < $c->bpt * (1500 + 3 * $c->land)  ) {
+        // sell if we don't have enough cash to build a bpt of farms
+        $pm_info = PrivateMarket::getInfo(); // TODO - cache?
+        $food_to_sell = ceil(min($c->food, $c->bpt * (1500 + 3 * $c->land) / $pm_info->sell_price->m_bu));
+        return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
+    } elseif (
+           $c->protection == 0
+        && $c->food > 7000
+        && (
+            $c->foodnet > 0 && $c->get_foodnet_no_decay() > 3 * $c->get_foodcon_no_decay() && $c->food > 30 * $c->get_foodnet_no_decay() //Don't sell less than 30 turns of food unless you're on your last turn (and desperate?)
+            || $c->turns == 1
+        )
+    ) { 
+        return sellextrafood_farmer($c, $rules, $bushel_min_sell_price, $bushel_max_sell_price, $cpref, $food_price_history);
+    } elseif ($c->shouldBuildFullBPT($target_bpt)) {
+        //build a full BPT if we can afford it
+        return Build::farmer($c);
+    } elseif ($c->shouldBuildFourCS($target_bpt)) {
+        //build 4CS if we can afford it and are below our target BPT (65)
+        return Build::cs(4); //build 4 CS
+    } elseif ($c->built() > 50) {  //otherwise... explore if we can
+        $explore_turn_limit = 2;
+        return explore($c, max(1,min($explore_turn_limit, $c->turns - 1, turns_of_money($c) - 4)));
+    } elseif($c->food > 0) { // better to sell on PM than cash
+        log_country_message($c->cnum, "Selling all food on PM in an attempt to avoid cashing turns");
+        return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
+    } else { //otherwise...  cash :(
+        return cash($c); // FUTURE - hold turns instead if food is on market?
+    }
+} // play_farmer_turn_first_1800_acres
+
+
+function play_farmer_turn_first_99_turns (&$c, $cpref, $target_bpt) {
+    if($c->food > 0 && $c->b_farm > 0) {
+        return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
+    } elseif($c->land < 600 && $c->built() > 50) {
+        // always explore when possible early on to get more income
+        return explore($c, 1);
+    } elseif ($c->shouldBuildSingleCS($target_bpt, 20)) {
+        return Build::cs(); //build 1 CS
+    } elseif ($c->shouldBuildFullBPT($target_bpt)) {
+        //build a full BPT if we can afford it
+        return Build::farmer($c);
+    } elseif ($c->shouldBuildFourCS($target_bpt)) {
+        //build 4CS if we can afford it and are below our target BPT (65)
+        return Build::cs(4); //build 4 CS
+    } else { //otherwise...  cash (shouldn't ever happen)
+        return cash($c);
+    }
+} // play_farmer_turn_first_99_turns
 
 
 function sellextrafood_farmer(&$c, $rules, $bushel_min_sell_price, $bushel_max_sell_price, $cpref, $food_price_history)
@@ -286,20 +344,3 @@ function farmer_switch_government_if_needed($c) {
 function farmer_get_buying_priorities ($cnum, $buying_schedule) {
     return casher_get_buying_priorities ($cnum, $buying_schedule); // same as casher for now
 } // farmer_get_buying_priorities()
-
-
-/*
-function farmerGoals(&$c)
-{
-    return [
-        //what, goal, priority
-        ['t_agri',227,1000],
-        ['t_bus',174,500],
-        ['t_res',174,500],
-        ['t_mil',95,200],
-        ['nlg',$c->nlgTarget(),200],
-        ['dpa',$c->defPerAcreTarget(1.0),1000],
-        ['food', 1000000000, 5],
-    ];
-}//end farmerGoals()
-*/

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -213,7 +213,7 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
 function play_farmer_turn_first_1800_acres (&$c, $cpref, $rules, $target_bpt, $bushel_min_sell_price, $bushel_max_sell_price, $food_price_history) {
     if($c->food > 0 && $c->b_farm > 0 && $c->empty >= $c->bpt && $c->money < $c->bpt * $c->build_cost) {
         // sell if we don't have enough cash to build a bpt of farms
-        $pm_info = PrivateMarket::getInfo(); // TODO - cache?
+        $pm_info = PrivateMarket::getInfo(); // FUTURE - cache?
         $food_to_sell = ceil(min($c->food, $c->bpt * $c->build_cost / $pm_info->sell_price->m_bu));
         return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
     } elseif (

--- a/farmer_strat.php
+++ b/farmer_strat.php
@@ -180,10 +180,10 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
         )
     ) { 
         // sell some food on PM if we have a lot of empty acres, still have turns, and can't afford to build at least 1k acres
-        if($c->turns > (1000 / $c->bpt) && $c->empty >= 1000 && $c->money < 1000 * (1500 + 3 * $c->land)) {        
+        if($c->turns > (1000 / $c->bpt) && $c->empty >= 1000 && $c->money < 1000 * $c->build_cost) {        
             log_country_message($c->cnum, "Selling food on PM because we have over 999 empty acres and not enough money to build them");    
             $pm_info = PrivateMarket::getInfo();
-            $food_to_sell = ceil(min($c->food, 1000 * (1500 + 3 * $c->land) / $pm_info->sell_price->m_bu));
+            $food_to_sell = ceil(min($c->food, 1000 * $c->build_cost / $pm_info->sell_price->m_bu));
             return PrivateMarket::sell_single_good($c, 'm_bu', $food_to_sell);
         }
         else
@@ -211,10 +211,10 @@ function play_farmer_turn(&$c, $cpref, $rules, $is_allowed_to_mass_explore, $bus
 
 
 function play_farmer_turn_first_1800_acres (&$c, $cpref, $rules, $target_bpt, $bushel_min_sell_price, $bushel_max_sell_price, $food_price_history) {
-    if($c->food > 0 && $c->b_farm > 0 && $c->empty >= $c->bpt && $c->money < $c->bpt * (1500 + 3 * $c->land)  ) {
+    if($c->food > 0 && $c->b_farm > 0 && $c->empty >= $c->bpt && $c->money < $c->bpt * $c->build_cost) {
         // sell if we don't have enough cash to build a bpt of farms
         $pm_info = PrivateMarket::getInfo(); // TODO - cache?
-        $food_to_sell = ceil(min($c->food, $c->bpt * (1500 + 3 * $c->land) / $pm_info->sell_price->m_bu));
+        $food_to_sell = ceil(min($c->food, $c->bpt * $c->build_cost / $pm_info->sell_price->m_bu));
         return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
     } elseif (
            $c->protection == 0

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -137,6 +137,12 @@ function play_indy_turn(&$c, $cpref, $server_max_possible_market_sell, $is_allow
         //1.15 is my growth factor for indies
         $explore_turn_limit = $is_allowed_to_mass_explore ? 999 : $cpref->spend_extra_money_cooldown_turns;
         return explore($c, max(1, min($explore_turn_limit, $c->turns - 1, turns_of_money($c) / 1.15 - 4, turns_of_food($c) - 4)));
+
+    } elseif(($c->m_tr + $c->m_j + $c->m_tu + $c->m_ta) > 0 && $c->empty >= $c->bpt && $c->money < $c->bpt * $c->build_cost) {
+        // sell if we don't have enough cash to build a bpt of indies
+        // shouldn't need to check income because money management takes care of it?
+        log_country_message($c->cnum, "Selling military on PM in an attempt to avoid cashing");
+        return emergency_sell_mil_on_pm ($c, $c->bpt * $c->build_cost - $c->money); // TODO: is it okay to return false/true?
     } else { //otherwise...  cash
         return cash($c);
     }
@@ -146,6 +152,10 @@ function play_indy_turn(&$c, $cpref, $server_max_possible_market_sell, $is_allow
 function play_indy_turn_first_1800_acres (&$c, $cpref, $target_bpt, $server_max_possible_market_sell) {
     if($c->turns_played <= 170 && $c->m_tu) {
         return PrivateMarket::sell_single_good($c, 'm_tu', $c->m_tu);
+    } elseif(($c->m_tr + $c->m_j + $c->m_tu + $c->m_ta) > 0 && $c->b_indy > 0 && $c->empty >= $c->bpt && $c->money < $c->bpt * $c->build_cost) {
+        // sell if we don't have enough cash to build a bpt of indies
+        log_country_message($c->cnum, "Selling military on PM in an attempt to avoid parking lot");
+        return emergency_sell_mil_on_pm ($c, $c->bpt * $c->build_cost - $c->money); // TODO: is it okay to return false/true?
     } elseif ( // TODO: takes forever remotely?
         $c->m_tu
         && $c->protection == 0
@@ -153,7 +163,7 @@ function play_indy_turn_first_1800_acres (&$c, $cpref, $target_bpt, $server_max_
         && ($c->turns == 1 || sellmilitarytime($c))
     ) {
         return sell_max_military($c, $server_max_possible_market_sell, $cpref);
-    } elseif ($c->shouldBuildFullBPT($target_bpt)) {
+    } elseif ($c->shouldBuildFullBPT($target_bpt)) { // TODO: why doesn't this work after emergency sell?
         //build a full BPT if we can afford it
         return Build::indy($c);
     } elseif ($c->shouldBuildFourCS($target_bpt)) {
@@ -163,8 +173,6 @@ function play_indy_turn_first_1800_acres (&$c, $cpref, $target_bpt, $server_max_
         //1.15 is my growth factor for indies
         $explore_turn_limit = 2;
         return explore($c, max(1, min($explore_turn_limit, $c->turns - 1, turns_of_money($c) / 1.15 - 4, turns_of_food($c) - 4)));
-    //} elseif($c->money < $c->bpt * (1500 + 3 * $c->land) && $c->m_tr + $c->m_j + $c->m_tu + $c->m_ta > 0) {
-    //    return emergency_sell_mil_on_pm ($c, $c->bpt * (1500 + 3 * $c->land) - $c->money); // TODO: is it okay to return false/true?
     } else { //otherwise...  cash - TODO: money management needs to be good enough so this doesn't ever happen
         return cash($c);
     }

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -215,7 +215,7 @@ function sellmilitarytime(&$c)
 }//end sellmilitarytime()
 
 
-function indy_switch_government_if_needed($c) {
+function indy_switch_government_if_needed(&$c) {
     if ($c->govt == 'M') {
         $rand = rand(0, 100);
         switch ($rand) {

--- a/indy_strat.php
+++ b/indy_strat.php
@@ -84,7 +84,6 @@ function play_indy_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$tur
             break; //HOLD TURNS HAS BEEN DECLARED; HOLD!!
         }
 
-        // TODO: tech buying?
         if (turns_of_food($c) > (10 + $c->turns) && turns_of_money($c) > (10 + $c->turns) && $c->money > 3500 * 500 && ($c->money > floor(0.8 * $c->fullBuildCost()) - $c->runCash())
         ) {
             if ($c->turns_played >= $turns_played_for_last_spend_money_attempt + $cpref->spend_extra_money_cooldown_turns) { // wait some number of turns before trying again
@@ -142,7 +141,7 @@ function play_indy_turn(&$c, $cpref, $server_max_possible_market_sell, $is_allow
         // sell if we don't have enough cash to build a bpt of indies
         // shouldn't need to check income because money management takes care of it?
         log_country_message($c->cnum, "Selling military on PM in an attempt to avoid cashing");
-        return emergency_sell_mil_on_pm ($c, $c->bpt * $c->build_cost - $c->money); // TODO: is it okay to return false/true?
+        return emergency_sell_mil_on_pm ($c, $c->bpt * $c->build_cost - $c->money); // FUTURE: is it okay to return false/true?
     } else { //otherwise...  cash
         return cash($c);
     }
@@ -155,15 +154,15 @@ function play_indy_turn_first_1800_acres (&$c, $cpref, $target_bpt, $server_max_
     } elseif(($c->m_tr + $c->m_j + $c->m_tu + $c->m_ta) > 0 && $c->b_indy > 0 && $c->empty >= $c->bpt && $c->money < $c->bpt * $c->build_cost) {
         // sell if we don't have enough cash to build a bpt of indies
         log_country_message($c->cnum, "Selling military on PM in an attempt to avoid parking lot");
-        return emergency_sell_mil_on_pm ($c, $c->bpt * $c->build_cost - $c->money); // TODO: is it okay to return false/true?
-    } elseif ( // TODO: takes forever remotely?
+        return emergency_sell_mil_on_pm ($c, $c->bpt * $c->build_cost - $c->money); // FUTURE: is it okay to return false/true?
+    } elseif ( // FUTURE: takes forever remotely?
         $c->m_tu
         && $c->protection == 0
         && total_cansell_military($c, $server_max_possible_market_sell) > 7500
         && ($c->turns == 1 || sellmilitarytime($c))
     ) {
         return sell_max_military($c, $server_max_possible_market_sell, $cpref);
-    } elseif ($c->shouldBuildFullBPT($target_bpt)) { // TODO: why doesn't this work after emergency sell?
+    } elseif ($c->shouldBuildFullBPT($target_bpt)) {
         //build a full BPT if we can afford it
         return Build::indy($c);
     } elseif ($c->shouldBuildFourCS($target_bpt)) {
@@ -173,7 +172,7 @@ function play_indy_turn_first_1800_acres (&$c, $cpref, $target_bpt, $server_max_
         //1.15 is my growth factor for indies
         $explore_turn_limit = 2;
         return explore($c, max(1, min($explore_turn_limit, $c->turns - 1, turns_of_money($c) / 1.15 - 4, turns_of_food($c) - 4)));
-    } else { //otherwise...  cash - TODO: money management needs to be good enough so this doesn't ever happen
+    } else { //otherwise...  cash - FUTURE: money management needs to be good enough so this doesn't ever happen
         return cash($c);
     }
 } // play_indy_turn_first_1800_acres

--- a/rainbow_strat.php
+++ b/rainbow_strat.php
@@ -73,7 +73,7 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
     while ($c->turns > 0) {
         //$result = PublicMarket::buy($c,array('m_bu'=>100),array('m_bu'=>400));
                 
-        $result = play_rainbow_turn($c, $rules->market_autobuy_tech_price, $rules->max_possible_market_sell);
+        $result = play_rainbow_turn($c, $cpref, $rules->market_autobuy_tech_price, $rules->max_possible_market_sell);
         if ($result === false) {  //UNEXPECTED RETURN VALUE
             $c = get_advisor();     //UPDATE EVERYTHING
             continue;
@@ -125,7 +125,7 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
 }//end play_rainbow_strat()
 
 
-function play_rainbow_turn(&$c, $market_autobuy_tech_price, $server_max_possible_market_sell)
+function play_rainbow_turn(&$c, $cpref, $market_autobuy_tech_price, $server_max_possible_market_sell)
 {
  //c as in country!
     $target_bpt = 65;

--- a/rainbow_strat.php
+++ b/rainbow_strat.php
@@ -106,7 +106,7 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
 
             if ($spend > abs($c->income) * 10) {
                 //try to batch a little bit...
-                buy_rainbow_goals($c, $spend);
+                buy_rainbow_goals($c, $cpref, $spend);
             }
         }
 
@@ -120,7 +120,7 @@ function play_rainbow_strat($server, $cnum, $rules, $cpref, &$exit_condition)
         //$main->turns = 0;             //use this to do one turn at a time
     }
 
-    $c->countryStats(RAINBOW, rainbowGoals($c));
+    //$c->countryStats(RAINBOW, rainbowGoals($c, $cpref));
     return $c;
 }//end play_rainbow_strat()
 
@@ -279,13 +279,13 @@ function tech_rainbow(&$c, $turns = 1)
 
 
 
-function buy_rainbow_goals(&$c, $spend = null)
+function buy_rainbow_goals(&$c, $cpref, $spend = null)
 {
-    Country::countryGoals($c, rainbowGoals($c), $spend);
+    Country::countryGoals($c, rainbowGoals($c, $cpref), $spend);
 }//end buy_rainbow_goals()
 
 
-function rainbowGoals(&$c)
+function rainbowGoals(&$c, $cpref)
 {
     return [
         //what, goal, priority
@@ -295,6 +295,6 @@ function rainbowGoals(&$c)
         ['t_res',145,7],
         ['t_mil',94,5],
         ['nlg',$c->nlgTarget(),5],
-        ['dpa',$c->defPerAcreTarget(),10],
+        ['dpa',$c->defPerAcreTarget($cpref),10],
     ];
 }//end rainbowGoals()

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -16,7 +16,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     $is_allowed_to_mass_explore = is_country_allowed_to_mass_explore($c, $cpref);
 
     if(!$cpref->techer_allowed_to_explore)
-        log_country_message($cnum, "Techer is not allowed to explore because it's too close to the end of the round");
+        log_country_message($cnum, "Not allowed to explore due to preference explore cutoff value of $cpref->techer_round_explore_cutoff_percentage");
 
     sell_initial_troops_on_turn_0($c);
 

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -31,8 +31,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
         Allies::fill($cpref, 'res');
     }
 
-    // TODO" DEBUG
-    // techer_switch_government_if_needed($c);
+    techer_switch_government_if_needed($c);
 
     $buying_priorities = [
         ['type'=>'DPA','goal'=>100],
@@ -135,9 +134,11 @@ function play_techer_turn(&$c, $cpref, $rules, $tech_price_min_sell_price, $is_a
     // FUTURE: why does building 4 cs become so slow? can_sell_tech? after protection? selltechtime ?
     // FUTURE: maybe split logic for < target BPT, < 1800 A, and otherwise
 
-    // TODO: need to call ee destroy API
     if($c->govt <> 'H' && $c->govt <> 'I' && $c->turns_played < 180) {
         return play_techer_turn_first_179_turns_for_most_gov($c, $cpref, $tpt_split);
+    } elseif($c->b_farm > 0 && $c->money > 1.2 * $c->build_cost * $c->b_farm) { 
+        // destroy any farms as soon as we have enough cash to replace with labs
+        return Build::destroy_all_of_one_type($c, 'farm');
     } elseif($c->land < 500 && $c->built() > 50) {
         // always explore when possible early on to get more income
         return explore($c, 1);
@@ -167,7 +168,7 @@ function play_techer_turn(&$c, $cpref, $rules, $tech_price_min_sell_price, $is_a
         $teching_turns_remaining_before_explore -= $turns_to_tech;
         return tech_techer($c, $turns_to_tech, $tpt_split);
     } elseif (
-        $cpref->techer_allowed_to_grow && $c->built() > 50 && $c->land < $cpref->techer_land_goal &&
+        $cpref->techer_allowed_to_explore && $c->built() > 50 && $c->land < $cpref->techer_land_goal &&
         (
             ($c->empty < 4 && $c->land < 1800) // always allow for early exploring (cs)
             ||

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -115,7 +115,7 @@ function play_techer_strat($server, $cnum, $rules, $cpref, &$exit_condition, &$t
     if($exit_condition = 'NORMAL' && $starting_turns > 30 && ($starting_turns - $c->turns) < 0.3 * $starting_turns)
         $exit_condition = 'LOW_TURNS_PLAYED'; 
 
-    $c->countryStats(TECHER);
+    //$c->countryStats(TECHER);
 
     return $c;
 }//end play_techer_strat()
@@ -387,15 +387,3 @@ function techer_switch_government_if_needed($c) {
         }
     }
 } // techer_switch_government_if_needed()
-
-
-/*
-function techerGoals(&$c)
-{
-    return [
-        //what, goal, priority
-        ['dpa', $c->defPerAcreTarget(1.0), 2],
-        ['nlg', $c->nlgTarget(),2 ],
-    ];
-}//end techerGoals()
-*/

--- a/techer_strat.php
+++ b/techer_strat.php
@@ -199,7 +199,7 @@ function play_techer_turn(&$c, $cpref, $rules, $tech_price_min_sell_price, $is_a
 
 // FUTURE figure out startup for theo?
 function play_techer_turn_first_179_turns_for_most_gov (&$c, $cpref, $tpt_split) {
-    if($c->food > 0 && $c->b_farm > 0 && $c->b_cs <= 120) {
+    if($c->food > 0 && $c->b_farm > 0 && $c->foodnet > 20 && $c->b_cs <= 120) {
         return PrivateMarket::sell_single_good($c, 'm_bu', $c->food);
     } elseif(($c->land < 400 && $c->built() > 50) || $c->empty < $c->bpt) {
         // always explore when possible early on to get more income


### PR DESCRIPTION
### PLANNED

- much better startups - also all strats (maybe not indy) should contribute to market by turn 180
- don't buy def at low acreage
- techers should stop growing at different times instead of all at once
- for farmer, allow spending of a small amount of money at end even if build costs are high
- some of the errors and notices
- need to test a full run on AI server


### BUMPED:

- change indy and tech production
- redo food and money management
- new rainbow - need to contribute oil
- cashers - cash when explore is no longer worth it
- SCHEDULE NAMES: D30_T10_D60_T40_D100
- reduce log spam in general
- return tech last price, shorten missed techs into a single line
- eliminate all errors - create warnings file
- add turn action array to delta snapshot
- race conditions for deleting and creating files/folders - take a lock
- Use the warning logging framework to detect bad initial start conditions:
-   max stored turns
-   too many stored turns
-   negative income and not enough money to play at least 4 turns
-   negative foodnet and not enough food to play at least 4 turns


### (NOT) POSSIBLE:

- reduce expenses during destocking if stock is spent - CIs can end up unable to play turns with $60 M cash (is this a big deal?)
- remove unnecessary update_c, get advisor, update main calls on ai servers
- redo DPA/NWPA
- spal preference, vary by country
- add cpref to not ME unless money is high???
- split personality file - saving the current one seems to be expensive
- destocking indies reserve money to play turns